### PR TITLE
MINOR: Improving utilities unit test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
             "unix"
         ],
         "camelcase": 0,
-        "no-unused-expressions": 0,
         "class-methods-use-this": 0,
         "no-unused-vars": 0,
         "no-return-assign": 0,

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -18,6 +18,15 @@ describe('Utilities module', () => {
 
         Utilities.loadConfig().then((result) => {
             myConfig = result;
+            assert.hasAllKeys(
+                result, ['node_wallet', 'node_private_key', 'node_rpc_ip', 'node_port',
+                    'node_kademlia_id', 'selected_graph_database', 'selected_blockchain', 'request_timeout', 'ssl_keypath',
+                    'ssl_certificate_path', 'private_extended_key_path', 'child_derivation_index', 'cpus', 'embedded_wallet_directory',
+                    'embedded_peercache_path', 'onion_virtual_port', 'traverse_nat_enabled', 'traverse_port_forward_ttl', 'verbose_logging',
+                    'control_port_enabled', 'control_port', 'control_sock_enabled', 'control_sock', 'onion_enabled', 'test_network',
+                    'ssl_authority_paths', 'network_bootstrap_nodes', 'solve_hashes', 'remote_access_whitelist', 'node_rpc_port'],
+                'Some config items are missing',
+            );
         });
     });
 
@@ -33,12 +42,14 @@ describe('Utilities module', () => {
 
     it('getRandomInt check', () => {
         const max11 = Utilities.getRandomInt(11);
-        assert.isAtLeast(max11, 0) && assert.isAtMost(max11, 11);
+        assert.isAtLeast(max11, 0);
+        assert.isAtMost(max11, 11);
     });
 
     it('getRandomIntRange check', () => {
         const max15max33 = Utilities.getRandomIntRange(15, 33);
-        assert.isAtLeast(max15max33, 15) && assert.isAtMost(max15max33, 33);
+        assert.isAtLeast(max15max33, 15);
+        assert.isAtMost(max15max33, 33);
     });
 
     it('getRandomString check', () => {


### PR DESCRIPTION
- since no eslint errors of type no-unused-expressions,
enabling on this rule again.