### PR TITLE
Fix - Litigation stake sending

### DIFF
--- a/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
+++ b/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
@@ -192,7 +192,8 @@ contract BiddingTest {
 	function cancelOffer(bytes32 import_id)
 	public{
 		OfferDefinition storage this_offer = offer[import_id];
-		require(this_offer.active && this_offer.DC_wallet == msg.sender);
+		require(this_offer.active && this_offer.DC_wallet == msg.sender
+			&& this_offer.finalized == false);
 		this_offer.active = false;
 		uint max_total_token_amount = this_offer.max_token_amount_per_DH.mul(this_offer.replication_factor.mul(2).add(1));
 		profile[msg.sender].balance = profile[msg.sender].balance.add(max_total_token_amount);

--- a/modules/Blockchain/Ethereum/contracts/Reading.sol
+++ b/modules/Blockchain/Ethereum/contracts/Reading.sol
@@ -1,4 +1,4 @@
-dpragma solidity ^0.4.21;
+pragma solidity ^0.4.21;
 
 library SafeMath {
 	function mul(uint256 a, uint256 b) internal pure returns (uint256) {
@@ -234,7 +234,7 @@ contract Reading is Ownable{
 		PurchaseDefinition storage this_purchase = purchase[msg.sender][DV_wallet][import_id];
 
 		require(this_purchase.purchase_status == PurchaseStatus.sent
-			&&  this_purchase.time_of_sending + 5 minutes =< block.timestamp);
+			&&  this_purchase.time_of_sending + 5 minutes <= block.timestamp);
 
 		bidding.increaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor).add(this_purchase.token_amount));
 		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));

--- a/modules/Blockchain/Ethereum/contracts/Reading.sol
+++ b/modules/Blockchain/Ethereum/contracts/Reading.sol
@@ -76,7 +76,7 @@ contract Reading is Ownable{
 	Bidding bidding;
 	address escrow;
 
- 	enum PurchaseStatus {inactive, initiated, commited, confirmed, sent, paid, disputed, cancelled, completed}
+ 	enum PurchaseStatus {inactive, initiated, commited, confirmed, sent, disputed, cancelled, completed}
 
 	struct PurchaseDefinition{
  		uint token_amount;
@@ -140,7 +140,8 @@ contract Reading is Ownable{
 	function initiatePurchase(bytes32 import_id, address DH_wallet, uint token_amount, uint stake_factor)
 	public {
 		PurchaseDefinition storage this_purchase = purchase[DH_wallet][msg.sender][import_id];
-		require(this_purchase.purchase_status == PurchaseStatus.inactive);
+		require(this_purchase.purchase_status == PurchaseStatus.inactive
+			|| 	this_purchase.purchase_status == PurchaseStatus.completed);
 
 		uint256 DH_balance = bidding.getBalance(DH_wallet);
 		uint256 DV_balance = bidding.getBalance(msg.sender);
@@ -238,7 +239,7 @@ contract Reading is Ownable{
 		bidding.increaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor).add(this_purchase.token_amount));
 		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));
 
-		this_purchase.purchase_status = PurchaseStatus.paid;
+		this_purchase.purchase_status = PurchaseStatus.completed;
 	}
 
 	function initiateDispute(bytes32 import_id, address DH_wallet)

--- a/modules/Blockchain/Ethereum/contracts/Reading.sol
+++ b/modules/Blockchain/Ethereum/contracts/Reading.sol
@@ -145,7 +145,7 @@ contract Reading is Ownable{
 		uint256 DH_balance = bidding.getBalance(DH_wallet);
 		uint256 DV_balance = bidding.getBalance(msg.sender);
 		uint256 stake_amount = token_amount.mul(stake_factor);
-		require(DH_balance > stake_amount && DV_balance > token_amount.add(stake_amount));
+		require(DH_balance >= stake_amount && DV_balance >= token_amount.add(stake_amount));
 
 		bidding.decreaseBalance(msg.sender, token_amount.add(stake_amount));
 
@@ -162,7 +162,7 @@ contract Reading is Ownable{
 		require(this_purchase.purchase_status == PurchaseStatus.initiated);
 
 		uint256 DH_balance = bidding.getBalance(msg.sender);
-		require(DH_balance > this_purchase.token_amount.mul(this_purchase.stake_factor));
+		require(DH_balance >= this_purchase.token_amount.mul(this_purchase.stake_factor));
 		bidding.decreaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor));
 
 		this_purchase.commitment = commitment;
@@ -233,7 +233,7 @@ contract Reading is Ownable{
 		PurchaseDefinition storage this_purchase = purchase[msg.sender][DV_wallet][import_id];
 
 		require(this_purchase.purchase_status == PurchaseStatus.sent
-			&&  this_purchase.time_of_sending + 5 minutes < block.timestamp);
+			&&  this_purchase.time_of_sending + 5 minutes =< block.timestamp);
 
 		bidding.increaseBalance(msg.sender, this_purchase.token_amount);
 		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));
@@ -246,7 +246,7 @@ contract Reading is Ownable{
 		PurchaseDefinition storage this_purchase = purchase[DH_wallet][msg.sender][import_id];
 
 		require(this_purchase.purchase_status == PurchaseStatus.sent
-			&&  this_purchase.time_of_sending + 5 minutes > block.timestamp);
+			&&  this_purchase.time_of_sending + 5 minutes >= block.timestamp);
 
 		this_purchase.purchase_status = PurchaseStatus.disputed;
 		emit PurchaseDisputed(import_id, DH_wallet, msg.sender);

--- a/modules/Blockchain/Ethereum/contracts/Reading.sol
+++ b/modules/Blockchain/Ethereum/contracts/Reading.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+dpragma solidity ^0.4.21;
 
 library SafeMath {
 	function mul(uint256 a, uint256 b) internal pure returns (uint256) {
@@ -235,7 +235,7 @@ contract Reading is Ownable{
 		require(this_purchase.purchase_status == PurchaseStatus.sent
 			&&  this_purchase.time_of_sending + 5 minutes =< block.timestamp);
 
-		bidding.increaseBalance(msg.sender, this_purchase.token_amount);
+		bidding.increaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor).add(this_purchase.token_amount));
 		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));
 
 		this_purchase.purchase_status = PurchaseStatus.paid;

--- a/modules/Blockchain/Ethereum/test/bidding.test.js
+++ b/modules/Blockchain/Ethereum/test/bidding.test.js
@@ -483,12 +483,12 @@ contract('Bidding testing', async (accounts) => {
         );
         await escrow.answerLitigation(
             import_id,
-            requested_data[requested_data_index + 1],
+            '',
             { from: accounts[litigators[1]] },
         );
 
         for (var i = 0; i < litigators.length; i += 1) {
-            // eslint-disable-next-line
+            // eslint-disable-next-line no-await-in-loop
             var response = await escrow.litigation.call(import_id, accounts[litigators[i]]);
             console.log(`\t litigation for profile ${litigators[i]}: ${JSON.stringify(response)}`);
         }
@@ -534,10 +534,12 @@ contract('Bidding testing', async (accounts) => {
 
         var promises = [];
         for (var i = 0; i < chosen_bids.length; i += 1) {
-            promises[i] = escrow.payOut(
-                import_id,
-                { from: accounts[chosen_bids[i]], gas: 100000 },
-            );
+            if (i !== litigators[1]) {
+                promises[i] = escrow.payOut(
+                    import_id,
+                    { from: accounts[chosen_bids[i]], gas: 100000 },
+                );
+            }
         }
         await Promise.all(promises);
 
@@ -565,10 +567,12 @@ contract('Bidding testing', async (accounts) => {
 
         var promises = [];
         for (var i = 0; i < chosen_bids.length; i += 1) {
-            promises[i] = escrow.payOut(
-                import_id,
-                { from: accounts[chosen_bids[i]], gas: 1000000 },
-            );
+            if (i !== litigators[1]) {
+                promises[i] = escrow.payOut(
+                    import_id,
+                    { from: accounts[chosen_bids[i]], gas: 1000000 },
+                );
+            }
         }
         await Promise.all(promises);
 

--- a/modules/Blockchain/Ethereum/test/bidding.test.js
+++ b/modules/Blockchain/Ethereum/test/bidding.test.js
@@ -115,8 +115,7 @@ contract('Bidding testing', async (accounts) => {
             // eslint-disable-next-line no-await-in-loop
             var response = await bidding.profile.call(accounts[i]);
 
-            console.log(`\t account price [${i}]: ${response[0].toNumber() / 1e18}`);
-            console.log(`\t account stake [${i}]: ${response[1].toNumber() / 1e18}`);
+            console.log(`\t account[${i}] price: ${response[0].toNumber() / 1e18} \t stake: ${response[1].toNumber() / 1e18}`);
 
             assert.equal(response[0].toNumber(), DH_price[i], 'Price not matching');
             assert.equal(response[1].toNumber(), DH_stake[i], 'Stake not matching');
@@ -184,7 +183,7 @@ contract('Bidding testing', async (accounts) => {
         // Data holding parameters
         const data_hash = await util.keccakAddressBytes(accounts[9], node_id[9]);
 
-        console.log(`\t Data hash ${data_hash}`);
+        console.log(`\t Data hash: ${data_hash}`);
 
         await bidding.createOffer(
             import_id,
@@ -316,9 +315,7 @@ contract('Bidding testing', async (accounts) => {
             chosen_bids[i] = chosen_bids[i].toNumber() + 1;
         }
 
-        await bidding.chooseBids(import_id).then((res) => {
-            console.log(res.tx);
-        });
+        await bidding.chooseBids(import_id);
     });
 
     // Merkle tree structure
@@ -534,10 +531,10 @@ contract('Bidding testing', async (accounts) => {
 
         var promises = [];
         for (var i = 0; i < chosen_bids.length; i += 1) {
-            if (i !== litigators[1]) {
+            if (chosen_bids[i] !== litigators[1]) {
                 promises[i] = escrow.payOut(
                     import_id,
-                    { from: accounts[chosen_bids[i]], gas: 100000 },
+                    { from: accounts[chosen_bids[i]], gas: 1000000 },
                 );
             }
         }
@@ -567,7 +564,7 @@ contract('Bidding testing', async (accounts) => {
 
         var promises = [];
         for (var i = 0; i < chosen_bids.length; i += 1) {
-            if (i !== litigators[1]) {
+            if (chosen_bids[i] !== litigators[1]) {
                 promises[i] = escrow.payOut(
                     import_id,
                     { from: accounts[chosen_bids[i]], gas: 1000000 },


### PR DESCRIPTION
Fixes
  - Corrected the amount of tokens sent to DH in reading smart contract in payOut function
  - Corrected token balance checking from > to >= in reading smart contract
  - Fixed litigation testing in truffle test
  - Added the ability for DV to purchase any data from a DH multiple times
  - Added requirement for offer cancellation. Offer must not be finalized when canceling an offer
