### PR TITLE
Bugfix/smart contract fixes

### DIFF
--- a/modules/Blockchain/Ethereum/bidding-contract/abi.json
+++ b/modules/Blockchain/Ethereum/bidding-contract/abi.json
@@ -229,6 +229,45 @@
     "type": "function"
   },
   {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "import_id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getDistanceParameters",
+    "outputs": [
+      {
+        "name": "node_hash",
+        "type": "bytes32"
+      },
+      {
+        "name": "data_hash",
+        "type": "bytes32"
+      },
+      {
+        "name": "distance",
+        "type": "uint256"
+      },
+      {
+        "name": "current_ranking",
+        "type": "uint256"
+      },
+      {
+        "name": "required_bid_amount",
+        "type": "uint256"
+      },
+      {
+        "name": "active_nodes_",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "constant": false,
     "inputs": [
       {
@@ -334,76 +373,6 @@
         "type": "bytes32"
       },
       {
-        "name": "DH_wallet",
-        "type": "address"
-      },
-      {
-        "name": "DH_node_id",
-        "type": "bytes32"
-      }
-    ],
-    "name": "calculateDistance",
-    "outputs": [
-      {
-        "name": "distance",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "import_id",
-        "type": "bytes32"
-      },
-      {
-        "name": "DH_node_id",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getDistanceParameters",
-    "outputs": [
-      {
-        "name": "node_hash",
-        "type": "bytes32"
-      },
-      {
-        "name": "data_hash",
-        "type": "bytes32"
-      },
-      {
-        "name": "distance",
-        "type": "uint256"
-      },
-      {
-        "name": "current_ranking",
-        "type": "uint256"
-      },
-      {
-        "name": "required_bid_amount",
-        "type": "uint256"
-      },
-      {
-        "name": "active_nodes_",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "import_id",
-        "type": "bytes32"
-      },
-      {
         "name": "DH_node_id",
         "type": "bytes32"
       }
@@ -480,6 +449,29 @@
     ],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "import_id",
+        "type": "bytes32"
+      },
+      {
+        "name": "DH_wallet",
+        "type": "address"
+      }
+    ],
+    "name": "calculateDistance",
+    "outputs": [
+      {
+        "name": "distance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/modules/Blockchain/Ethereum/contracts/Bidding.sol
+++ b/modules/Blockchain/Ethereum/contracts/Bidding.sol
@@ -90,6 +90,8 @@ contract Bidding {
 		bool active;
 		bool finalized;
 
+		// uint256 offer_creation_timestamp;
+
 		BidDefinition[] bid;
 	}
 
@@ -125,7 +127,7 @@ contract Bidding {
 	}
 
 	uint256 public active_nodes;
-	mapping(bytes32 => OfferDefinition) public offer; //offer[import_id] import_id = keccak256(DC_wallet, DC_node_id, nonce)
+	mapping(bytes32 => OfferDefinition) public offer; //offer[import_id] import_id
 	mapping(address => ProfileDefinition) public profile; //profile[wallet]
 
 	event OfferCreated(bytes32 import_id, bytes32 DC_node_id, uint total_escrow_time_in_minutes, uint max_token_amount_per_DH, uint min_stake_amount_per_DH, uint min_reputation, uint data_size_in_bytes, bytes32 data_hash);
@@ -169,7 +171,7 @@ contract Bidding {
 		this_offer.min_stake_amount_per_DH = min_stake_amount_per_DH;
 		this_offer.min_reputation = min_reputation;
 
-		this_offer.data_hash = bytes32(uint256(data_hash) & (2**128-1));
+		this_offer.data_hash = data_hash;
 		this_offer.data_size_in_bytes = data_size_in_bytes;
 
 		this_offer.replication_factor = predetermined_DH_wallet.length;
@@ -178,6 +180,7 @@ contract Bidding {
 		this_offer.finalized = false;
 
 		this_offer.first_bid_index = uint(-1);
+		// this_offer.offer_creation_timestamp = block.timestamp;
 
 		//Writing the predetermined DC into the bid list
 		while(this_offer.bid.length < predetermined_DH_wallet.length) {
@@ -193,7 +196,8 @@ contract Bidding {
 	function cancelOffer(bytes32 import_id)
 	public{
 		OfferDefinition storage this_offer = offer[import_id];
-		require(this_offer.active && this_offer.DC_wallet == msg.sender);
+		require(this_offer.active && this_offer.DC_wallet == msg.sender
+			&& this_offer.finalized == false);
 		this_offer.active = false;
 		uint max_total_token_amount = this_offer.max_token_amount_per_DH.mul(this_offer.replication_factor.mul(2).add(1));
 		profile[msg.sender].balance = profile[msg.sender].balance.add(max_total_token_amount);
@@ -228,7 +232,7 @@ contract Bidding {
 		OfferDefinition storage this_offer = offer[import_id];
 
 		node_hash = bytes32((2**128 - 1) & uint256(keccak256(msg.sender, DH_node_id)));
-		data_hash = this_offer.data_hash;
+		data_hash = bytes32(uint128(this_offer.data_hash));
 
 
 		distance = calculateDistance(import_id, msg.sender, DH_node_id);
@@ -324,7 +328,8 @@ contract Bidding {
 		OfferDefinition storage this_offer = offer[import_id];
 		require(this_offer.active && !this_offer.finalized);
 		require(this_offer.replication_factor.mul(3).add(1) <= this_offer.bid.length);
-
+		// require(this_offer.offer_creation_timestamp + 5 minutes < block.timestamp);
+		
 		chosen_data_holders = new uint256[](this_offer.replication_factor.mul(2).add(1));
 
 		uint256 i;
@@ -556,11 +561,11 @@ contract Bidding {
 		else reputation = (log2(this_DH.reputation / this_DH.number_of_escrows) * corrective_factor / 115) / (corrective_factor / 100);
 		if(reputation == 0) reputation = 1;
 
-		uint256 hash_difference = absoluteDifference(uint256(this_offer.data_hash), (2**128 - 1) & uint256(keccak256(DH_wallet, DH_node_id)));
+		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet, DH_node_id))));
 
-		uint256 hash_f = ((uint256(this_offer.data_hash) * (2**128)) / (hash_difference + uint256(this_offer.data_hash)));
+		uint256 hash_f = ((uint256(uint128(this_offer.data_hash)) * (2**128)) / (hash_difference + uint256(uint128(this_offer.data_hash))));
 		uint256 price_f = corrective_factor - ((corrective_factor * token_amount) / this_offer.max_token_amount_per_DH);
-		uint256 stake_f = ((corrective_factor - ((this_offer.min_stake_amount_per_DH * corrective_factor) / stake_amount)) * uint256(this_offer.data_hash)) / (hash_difference + uint256(this_offer.data_hash));
+		uint256 stake_f = ((corrective_factor - ((this_offer.min_stake_amount_per_DH * corrective_factor) / stake_amount)) * uint256(uint128(this_offer.data_hash))) / (hash_difference + uint256(uint128(this_offer.data_hash)));
 		uint256 rep_f = (corrective_factor - (this_offer.min_reputation * corrective_factor / reputation));
 		distance = ((hash_f * (corrective_factor + price_f + stake_f + rep_f)) / 4) / corrective_factor;
 	}

--- a/modules/Blockchain/Ethereum/contracts/Bidding.sol
+++ b/modules/Blockchain/Ethereum/contracts/Bidding.sol
@@ -227,15 +227,15 @@ contract Bidding {
 		this_bid.active = true;
 	}
 
-	function getDistanceParameters(bytes32 import_id, bytes32 DH_node_id)
+	function getDistanceParameters(bytes32 import_id)
 	public view returns (bytes32 node_hash, bytes32 data_hash, uint256 distance, uint256 current_ranking, uint256 required_bid_amount, uint256 active_nodes_){
 		OfferDefinition storage this_offer = offer[import_id];
 
-		node_hash = bytes32((2**128 - 1) & uint256(keccak256(msg.sender, DH_node_id)));
+		node_hash = bytes32(uint128(keccak256(msg.sender)));
 		data_hash = bytes32(uint128(this_offer.data_hash));
 
 
-		distance = calculateDistance(import_id, msg.sender, DH_node_id);
+		distance = calculateDistance(import_id, msg.sender);
 		required_bid_amount = this_offer.replication_factor.mul(2).add(1);
 		active_nodes_ = active_nodes;
 
@@ -269,7 +269,7 @@ contract Bidding {
 		//Create new bid in the list
 		uint this_bid_index = this_offer.bid.length;
 		BidDefinition memory new_bid = BidDefinition(msg.sender, DH_node_id, this_DH.token_amount_per_byte_minute * scope, this_DH.stake_amount_per_byte_minute * scope, 0, uint(-1), true, false);
-		new_bid.distance = calculateDistance(import_id, msg.sender, DH_node_id);
+		new_bid.distance = calculateDistance(import_id, msg.sender);
 
 		distance = new_bid.distance;
 
@@ -546,7 +546,7 @@ contract Bidding {
 	// Constant values used for distance calculation
 	uint256 corrective_factor = 10**10;
 
-	function calculateDistance(bytes32 import_id, address DH_wallet, bytes32 DH_node_id)
+	function calculateDistance(bytes32 import_id, address DH_wallet)
 	public view returns (uint256 distance) {
 		OfferDefinition storage this_offer = offer[import_id];
 		ProfileDefinition storage this_DH = profile[DH_wallet];
@@ -561,7 +561,7 @@ contract Bidding {
 		else reputation = (log2(this_DH.reputation / this_DH.number_of_escrows) * corrective_factor / 115) / (corrective_factor / 100);
 		if(reputation == 0) reputation = 1;
 
-		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet, DH_node_id))));
+		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet))));
 
 		uint256 hash_f = ((uint256(uint128(this_offer.data_hash)) * (2**128)) / (hash_difference + uint256(uint128(this_offer.data_hash))));
 		uint256 price_f = corrective_factor - ((corrective_factor * token_amount) / this_offer.max_token_amount_per_DH);

--- a/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
+++ b/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
@@ -171,7 +171,7 @@ contract BiddingTest {
 		this_offer.min_stake_amount_per_DH = min_stake_amount_per_DH;
 		this_offer.min_reputation = min_reputation;
 
-		this_offer.data_hash = bytes32(uint256(data_hash) & (2**128-1));
+		this_offer.data_hash = data_hash;
 		this_offer.data_size_in_bytes = data_size_in_bytes;
 
 		this_offer.replication_factor = predetermined_DH_wallet.length;
@@ -232,7 +232,7 @@ contract BiddingTest {
 		OfferDefinition storage this_offer = offer[import_id];
 
 		node_hash = bytes32((2**128 - 1) & uint256(keccak256(msg.sender, DH_node_id)));
-		data_hash = this_offer.data_hash;
+		data_hash = bytes32(uint128(this_offer.data_hash));
 
 
 		distance = calculateDistance(import_id, msg.sender, DH_node_id);
@@ -561,11 +561,11 @@ contract BiddingTest {
 		else reputation = (log2(this_DH.reputation / this_DH.number_of_escrows) * corrective_factor / 115) / (corrective_factor / 100);
 		if(reputation == 0) reputation = 1;
 
-		uint256 hash_difference = absoluteDifference(uint256(this_offer.data_hash), (2**128 - 1) & uint256(keccak256(DH_wallet, DH_node_id)));
+		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet, DH_node_id))));
 
-		uint256 hash_f = ((uint256(this_offer.data_hash) * (2**128)) / (hash_difference + uint256(this_offer.data_hash)));
+		uint256 hash_f = ((uint256(uint128(this_offer.data_hash)) * (2**128)) / (hash_difference + uint256(uint128(this_offer.data_hash))));
 		uint256 price_f = corrective_factor - ((corrective_factor * token_amount) / this_offer.max_token_amount_per_DH);
-		uint256 stake_f = ((corrective_factor - ((this_offer.min_stake_amount_per_DH * corrective_factor) / stake_amount)) * uint256(this_offer.data_hash)) / (hash_difference + uint256(this_offer.data_hash));
+		uint256 stake_f = ((corrective_factor - ((this_offer.min_stake_amount_per_DH * corrective_factor) / stake_amount)) * uint256(uint128(this_offer.data_hash))) / (hash_difference + uint256(uint128(this_offer.data_hash)));
 		uint256 rep_f = (corrective_factor - (this_offer.min_reputation * corrective_factor / reputation));
 		distance = ((hash_f * (corrective_factor + price_f + stake_f + rep_f)) / 4) / corrective_factor;
 	}

--- a/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
+++ b/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
@@ -127,7 +127,7 @@ contract BiddingTest {
 	}
 
 	uint256 public active_nodes;
-	mapping(bytes32 => OfferDefinition) public offer; //offer[import_id] import_id = keccak256(DC_wallet, DC_node_id, nonce)
+	mapping(bytes32 => OfferDefinition) public offer; //offer[import_id] import_id
 	mapping(address => ProfileDefinition) public profile; //profile[wallet]
 
 	event OfferCreated(bytes32 import_id, bytes32 DC_node_id, uint total_escrow_time_in_minutes, uint max_token_amount_per_DH, uint min_stake_amount_per_DH, uint min_reputation, uint data_size_in_bytes, bytes32 data_hash);

--- a/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
+++ b/modules/Blockchain/Ethereum/contracts/BiddingTest.sol
@@ -227,15 +227,15 @@ contract BiddingTest {
 		this_bid.active = true;
 	}
 
-	function getDistanceParameters(bytes32 import_id, bytes32 DH_node_id)
+	function getDistanceParameters(bytes32 import_id)
 	public view returns (bytes32 node_hash, bytes32 data_hash, uint256 distance, uint256 current_ranking, uint256 required_bid_amount, uint256 active_nodes_){
 		OfferDefinition storage this_offer = offer[import_id];
 
-		node_hash = bytes32((2**128 - 1) & uint256(keccak256(msg.sender, DH_node_id)));
+		node_hash = bytes32(uint128(keccak256(msg.sender)));
 		data_hash = bytes32(uint128(this_offer.data_hash));
 
 
-		distance = calculateDistance(import_id, msg.sender, DH_node_id);
+		distance = calculateDistance(import_id, msg.sender);
 		required_bid_amount = this_offer.replication_factor.mul(2).add(1);
 		active_nodes_ = active_nodes;
 
@@ -269,7 +269,7 @@ contract BiddingTest {
 		//Create new bid in the list
 		uint this_bid_index = this_offer.bid.length;
 		BidDefinition memory new_bid = BidDefinition(msg.sender, DH_node_id, this_DH.token_amount_per_byte_minute * scope, this_DH.stake_amount_per_byte_minute * scope, 0, uint(-1), true, false);
-		new_bid.distance = calculateDistance(import_id, msg.sender, DH_node_id);
+		new_bid.distance = calculateDistance(import_id, msg.sender);
 
 		distance = new_bid.distance;
 
@@ -546,7 +546,7 @@ contract BiddingTest {
 	// Constant values used for distance calculation
 	uint256 corrective_factor = 10**10;
 
-	function calculateDistance(bytes32 import_id, address DH_wallet, bytes32 DH_node_id)
+	function calculateDistance(bytes32 import_id, address DH_wallet)
 	public view returns (uint256 distance) {
 		OfferDefinition storage this_offer = offer[import_id];
 		ProfileDefinition storage this_DH = profile[DH_wallet];
@@ -561,7 +561,7 @@ contract BiddingTest {
 		else reputation = (log2(this_DH.reputation / this_DH.number_of_escrows) * corrective_factor / 115) / (corrective_factor / 100);
 		if(reputation == 0) reputation = 1;
 
-		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet, DH_node_id))));
+		uint256 hash_difference = absoluteDifference(uint256(uint128(this_offer.data_hash)), uint256(uint128(keccak256(DH_wallet))));
 
 		uint256 hash_f = ((uint256(uint128(this_offer.data_hash)) * (2**128)) / (hash_difference + uint256(uint128(this_offer.data_hash))));
 		uint256 price_f = corrective_factor - ((corrective_factor * token_amount) / this_offer.max_token_amount_per_DH);

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -318,6 +318,7 @@ library SafeMath {
 
  		require(this_escrow.DC_wallet == msg.sender && this_escrow.escrow_status == EscrowStatus.active);
  		require(this_litigation.litigation_status == LitigationStatus.inactive || this_litigation.litigation_status == LitigationStatus.completed);
+          require(block.timestamp < this_escrow.end_time);
 
  		this_litigation.requested_data_index = requested_data_index;
  		this_litigation.hash_array = hash_array;

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -428,6 +428,9 @@ library SafeMath {
      		this_escrow.escrow_status = EscrowStatus.completed;
 
      		reading.removeReadData(import_id, DH_wallet);
+
+               emit LitigationCompleted(import_id, DH_wallet, true);
+               return true;
      	}
 
      	uint256 i = 0;
@@ -488,6 +491,7 @@ library SafeMath {
 
      		reading.removeReadData(import_id, DH_wallet);
      		emit LitigationCompleted(import_id, DH_wallet, true);
+               return true;
      	}
      }
  }

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -317,7 +317,7 @@ library SafeMath {
  		EscrowDefinition storage this_escrow = escrow[import_id][DH_wallet];
 
  		require(this_escrow.DC_wallet == msg.sender && this_escrow.escrow_status == EscrowStatus.active);
- 		require(this_litigation.litigation_start_time == 0 || this_litigation.litigation_status == LitigationStatus.completed);
+ 		require(this_litigation.litigation_status == LitigationStatus.inactive || this_litigation.litigation_status == LitigationStatus.completed);
 
  		this_litigation.requested_data_index = requested_data_index;
  		this_litigation.hash_array = hash_array;
@@ -333,7 +333,7 @@ library SafeMath {
  		LitigationDefinition storage this_litigation = litigation[import_id][msg.sender];
  		EscrowDefinition storage this_escrow = escrow[import_id][msg.sender];
 
- 		require(this_litigation.litigation_start_time > 0 && this_litigation.litigation_status == LitigationStatus.initiated);
+ 		require(this_litigation.litigation_status == LitigationStatus.initiated);
 
  		if(block.timestamp > this_litigation.litigation_start_time + 15 minutes){
  			this_litigation.litigation_status = LitigationStatus.completed;

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -214,8 +214,8 @@ library SafeMath {
 
  		uint256 amount_to_send;
 
- 		uint end_time = block.timestamp;
- 		if(end_time > this_escrow.end_time){
+ 		uint current_time = block.timestamp;
+ 		if(current_time > this_escrow.end_time){
  			uint stake_to_send = this_escrow.stake_amount;
  			this_escrow.stake_amount = 0;
  			if(stake_to_send > 0) {
@@ -228,8 +228,8 @@ library SafeMath {
  			emit EscrowCompleted(import_id, msg.sender);
  		}
  		else{
- 			amount_to_send = SafeMath.mul(this_escrow.token_amount,SafeMath.sub(end_time,this_escrow.last_confirmation_time)) / this_escrow.total_time_in_seconds;
- 			this_escrow.last_confirmation_time = end_time;
+ 			amount_to_send = SafeMath.mul(this_escrow.token_amount,SafeMath.sub(current_time,this_escrow.last_confirmation_time)) / this_escrow.total_time_in_seconds;
+ 			this_escrow.last_confirmation_time = current_time;
  		}
  		
  		if(amount_to_send > 0) {
@@ -408,9 +408,6 @@ library SafeMath {
      		this_escrow.escrow_status = EscrowStatus.completed;
 
      		reading.removeReadData(import_id, DH_wallet);
-
-     		bidding.increaseBalance(msg.sender, this_escrow.stake_amount);
-     		this_escrow.stake_amount = 0;
      	}
 
      	uint256 i = 0;
@@ -470,9 +467,6 @@ library SafeMath {
      		this_escrow.escrow_status = EscrowStatus.completed;
 
      		reading.removeReadData(import_id, DH_wallet);
-
-     		bidding.increaseBalance(msg.sender, this_escrow.stake_amount);
-     		this_escrow.stake_amount = 0;
      		emit LitigationCompleted(import_id, DH_wallet, true);
      	}
      }

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -361,7 +361,7 @@ library SafeMath {
                this_litigation.litigation_status = LitigationStatus.completed;
                this_escrow.escrow_status = EscrowStatus.completed;
 
-               reading.removeReadData(import_id, DH_wallet);
+               reading.removeReadData(import_id, msg.sender);
  			emit LitigationTimedOut(import_id, msg.sender);
  			return false;
  		}

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -336,12 +336,31 @@ library SafeMath {
  		require(this_litigation.litigation_status == LitigationStatus.initiated);
 
  		if(block.timestamp > this_litigation.litigation_start_time + 15 minutes){
- 			this_litigation.litigation_status = LitigationStatus.completed;
- 			this_escrow.escrow_status = EscrowStatus.completed;
- 			//TODO Transfer remaining escrow tokens
- 			reading.removeReadData(import_id, msg.sender);
- 			bidding.increaseBalance(this_escrow.DC_wallet, this_escrow.stake_amount);
- 			this_escrow.stake_amount = 0;
+ 			uint256 amount_to_send;
+
+               uint cancelation_time = this_litigation.litigation_start_time;
+               amount_to_send = SafeMath.mul(this_escrow.token_amount, SafeMath.sub(this_escrow.end_time,cancelation_time)) / this_escrow.total_time_in_seconds;
+
+               //Transfer the amount_to_send to DC 
+               if(amount_to_send > 0) {
+                    this_escrow.tokens_sent = this_escrow.tokens_sent.add(amount_to_send);
+                    bidding.increaseBalance(this_escrow.DC_wallet, amount_to_send);
+               }
+               //Calculate the amount to send back to DH and transfer the money back
+               amount_to_send = SafeMath.sub(this_escrow.token_amount, this_escrow.tokens_sent);
+               if(amount_to_send > 0) {
+                    this_escrow.tokens_sent = this_escrow.tokens_sent.add(amount_to_send);
+                    bidding.increaseBalance(msg.sender, amount_to_send);
+               }
+
+               uint stake_to_send = this_escrow.stake_amount;
+               this_escrow.stake_amount = 0;
+               if(stake_to_send > 0) bidding.increaseBalance(msg.sender, amount_to_send);
+
+               this_litigation.litigation_status = LitigationStatus.completed;
+               this_escrow.escrow_status = EscrowStatus.completed;
+
+               reading.removeReadData(import_id, DH_wallet);
  			emit LitigationTimedOut(import_id, msg.sender);
  			return false;
  		}

--- a/modules/Blockchain/Ethereum/contracts/Escrow.sol
+++ b/modules/Blockchain/Ethereum/contracts/Escrow.sol
@@ -229,7 +229,8 @@ library SafeMath {
  		}
  		else{
  			amount_to_send = SafeMath.mul(this_escrow.token_amount,SafeMath.sub(current_time,this_escrow.last_confirmation_time)) / this_escrow.total_time_in_seconds;
- 			this_escrow.last_confirmation_time = current_time;
+ 	          assert(amount_to_send.add(this_escrow.tokens_sent) <= this_escrow.token_amount);
+               this_escrow.last_confirmation_time = current_time;
  		}
  		
  		if(amount_to_send > 0) {

--- a/modules/Blockchain/Ethereum/contracts/Reading.sol
+++ b/modules/Blockchain/Ethereum/contracts/Reading.sol
@@ -29,6 +29,7 @@ library SafeMath {
 contract Bidding{
 	function increaseBalance(address wallet, uint amount) public;
 	function decreaseBalance(address wallet, uint amount) public;
+	function increaseReputation(address wallet, uint amount) public;
 	function getBalance(address wallet) public view returns (uint256);
 }
 
@@ -237,6 +238,9 @@ contract Reading is Ownable{
 			&&  this_purchase.time_of_sending + 5 minutes <= block.timestamp);
 
 		bidding.increaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor).add(this_purchase.token_amount));
+		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));
+
+		bidding.increaseBalance(msg.sender, this_purchase.token_amount.mul(this_purchase.stake_factor));
 		bidding.increaseBalance(DV_wallet, this_purchase.token_amount.mul(this_purchase.stake_factor));
 
 		this_purchase.purchase_status = PurchaseStatus.completed;

--- a/modules/Blockchain/Ethereum/test/bidding.test.js
+++ b/modules/Blockchain/Ethereum/test/bidding.test.js
@@ -19,6 +19,7 @@ const total_escrow_time = 1;
 const max_token_amount = 1000e18;
 const min_stake_amount = 10e12;
 const min_reputation = 0;
+const predestined_first_bid_index = 9;
 
 // Profile variables
 var chosen_bids = [];
@@ -181,7 +182,7 @@ contract('Bidding testing', async (accounts) => {
         predetermined_node_id.push(node_id[2]);
 
         // Data holding parameters
-        const data_hash = await util.keccakAddressBytes(accounts[9], node_id[9]);
+        const data_hash = await util.keccakSender({ from: accounts[predestined_first_bid_index]});
 
         console.log(`\t Data hash: ${data_hash}`);
 
@@ -282,7 +283,7 @@ contract('Bidding testing', async (accounts) => {
             console.log(`\t first_bid_index =  ${first_bid_index} (node[${first_bid_index + 1}])`);
         }
 
-        assert.equal(first_bid_index, 8, 'Something wrong');
+        assert.equal(first_bid_index, predestined_first_bid_index - 1, 'Something wrong');
     });
 
     // EscrowDefinition

--- a/modules/Blockchain/Ethereum/test/bidding.test.js
+++ b/modules/Blockchain/Ethereum/test/bidding.test.js
@@ -182,7 +182,7 @@ contract('Bidding testing', async (accounts) => {
         predetermined_node_id.push(node_id[2]);
 
         // Data holding parameters
-        const data_hash = await util.keccakSender({ from: accounts[predestined_first_bid_index]});
+        const data_hash = await util.keccakSender({ from: accounts[predestined_first_bid_index] });
 
         console.log(`\t Data hash: ${data_hash}`);
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "restify": "^7.1.0",
     "restify-cors-middleware": "^1.1.0",
     "rimraf": "^2.6.2",
+    "scrypt": "^6.0.3",
     "semaphore-async-await": "^1.5.1",
     "sequelize": "^4.37.6",
     "sequelize-cli": "^4.0.0",


### PR DESCRIPTION
## Proposed Changes

  - Storing entire offer data hash instead of only lower 128 bits
  - Removing the use of DH_node_id in calculation of bid distance
  - Renaming end_time to current_time in escrow payOut function
  - Adding litigation requirement that it cannot be initiated after the escrow end time
  - Distributing tokens in answerLitigation when the timeout has run out
  - Removing redundant stake sending in escrow litigation
  - Adding assertion of token amount when calculating amount of tokens to send in escrow payOut function
  - Removing litigation start time requirements and using litigation status instead
  - Exiting proveLitigation function without unnecessary hash calculation when DH failed to answer
  - Increasing DH and DV reputation after successful data purchase
