### PR TITLE
Bugfix: Fingerprint overwrite

### DIFF
--- a/modules/Blockchain/Ethereum/contracts/OTFingerprintStore.sol
+++ b/modules/Blockchain/Ethereum/contracts/OTFingerprintStore.sol
@@ -27,7 +27,7 @@ contract OTFingerprintStore is Ownable{
     uint256 public _version;
     /* Data Holder Fingerprint Store */ 
     // mapping(address => mapping (bytes32 => bytes32)) public DHFS; 
-    mapping(address => mapping (bytes32 => bytes32[])) public DHFS; 
+    mapping(address => mapping (bytes32 => bytes32)) public DHFS; 
     /* Agreement store */
     struct Agreement {
         uint256 startTime;
@@ -53,13 +53,13 @@ contract OTFingerprintStore is Ownable{
         require(msg.sender!=address(0));
         require(batch_id_hash!=0x0);
         require(graph_hash!=0x0);
-        DHFS[msg.sender][batch_id_hash].push(graph_hash);
+        DHFS[msg.sender][batch_id_hash] = graph_hash;
         emit Fingerprint(msg.sender,batch_id,batch_id_hash,graph_hash);      
     }
     function getFingerprintByBatchHash(address dataHolder, bytes32 batch_id_hash) public constant returns (bytes32 fingerprint){
         require(dataHolder!=address(0));
         require(batch_id_hash!=0x0);
-        return DHFS[dataHolder][batch_id_hash][DHFS[dataHolder][batch_id_hash].length - 1];
+        return DHFS[dataHolder][batch_id_hash];
     }
     /* Agreements */ 
     function createAgreement(address dataHolder, uint256 startTime, uint256 endTime,bytes32 batch_id_hash, bytes32 data_hash) public returns (bool){

--- a/modules/Blockchain/Ethereum/contracts/OTFingerprintStore.sol
+++ b/modules/Blockchain/Ethereum/contracts/OTFingerprintStore.sol
@@ -53,6 +53,7 @@ contract OTFingerprintStore is Ownable{
         require(msg.sender!=address(0));
         require(batch_id_hash!=0x0);
         require(graph_hash!=0x0);
+        require(DHFS[msg.sender][batch_id_hash] == bytes32(0));
         DHFS[msg.sender][batch_id_hash] = graph_hash;
         emit Fingerprint(msg.sender,batch_id,batch_id_hash,graph_hash);      
     }

--- a/seeders/20180407223548-blockchain_data.js
+++ b/seeders/20180407223548-blockchain_data.js
@@ -12,7 +12,7 @@ module.exports = {
         network_id: 'rinkeby',
         gas_limit: '800000',
         gas_price: '5000000000',
-        ot_contract_address: '0x8126e8a02bcae11a631d4413b9bd4f01f14e045d',
+        ot_contract_address: '0x826b0e0b03f22c5e58557456bd8b8ede318c2e0a',
         token_contract_address: '0x98d9a611ad1b5761bdc1daac42c48e4d54cf5882',
         escrow_contract_address: '0xf0eda3784d79af89cd12863be65190636c5a6d3e',
         bidding_contract_address: '0x39f92a3bf4442d17f4f2d35fa085fe382186427f',


### PR DESCRIPTION
Fixes #
Prevents overwriting of an OT fingerprint, making the graph hash immutable
## Proposed Changes

  - Convert the DHFS in OTFingerprint smart contract from an array to a single bytes32 hash
  - When adding a fingerprint, requires that the current fingerprint is 0, ie not written yet
