### PR TITLE
Enable free of charge purchasing

### DIFF
--- a/modules/EventEmitter.js
+++ b/modules/EventEmitter.js
@@ -931,7 +931,7 @@ class EventEmitter {
                 logger.warn(returnMessage);
                 return;
             }
-            await dhService.handleDataReadRequest(message);
+            await dhController.handleDataReadRequestFree(message);
         });
 
         // async
@@ -951,7 +951,7 @@ class EventEmitter {
             }
 
             try {
-                await dvService.handleDataReadResponse(message);
+                await dvController.handleDataReadResponseFree(message);
             } catch (error) {
                 logger.warn(`Failed to process data read response. ${error}.`);
                 notifyError(error);

--- a/modules/EventEmitter.js
+++ b/modules/EventEmitter.js
@@ -345,7 +345,7 @@ class EventEmitter {
                 import_id,
                 root_hash,
                 total_documents,
-                wallet,
+                wallet, // TODO: Sender's wallet is ignored for now.
                 vertices,
             } = response;
 
@@ -355,7 +355,7 @@ class EventEmitter {
                     .create({
                         import_id,
                         root_hash,
-                        data_provider_wallet: wallet,
+                        data_provider_wallet: config.node_wallet,
                         import_timestamp: new Date(),
                         total_documents,
                         data_size: dataSize,

--- a/modules/command/dh/dh-data-read-request-free-command.js
+++ b/modules/command/dh/dh-data-read-request-free-command.js
@@ -1,0 +1,165 @@
+const Models = require('../../../models/index');
+const Command = require('../command');
+
+const BN = require('bn.js');
+const Utilities = require('../../Utilities');
+const ImportUtilities = require('../../ImportUtilities');
+const Graph = require('../../Graph');
+
+/**
+ * Free read request command.
+ */
+class DHDataReadRequestFreeCommand extends Command {
+    constructor(ctx) {
+        super(ctx);
+        this.logger = ctx.logger;
+        this.graphStorage = ctx.graphStorage;
+        this.config = ctx.config;
+        this.web3 = ctx.web3;
+        this.network = ctx.network;
+    }
+
+    /**
+     * Executes command and produces one or more events
+     * @param command
+     * @param transaction
+     */
+    async execute(command, transaction) {
+        const {
+            message,
+        } = command.data;
+
+        /*
+            message: {
+                id: REPLY_ID,
+                import_id: IMPORT_ID,
+                wallet: DH_WALLET,
+                nodeId: KAD_ID
+            }
+        */
+
+        // TODO in order to avoid getting a different import.
+        const {
+            nodeId, wallet, id, import_id,
+        } = message;
+        try {
+            // Check is it mine offer.
+            const networkReplyModel = await Models.network_replies.find({ where: { id } });
+            if (!networkReplyModel) {
+                throw Error(`Couldn't find reply with ID ${id}.`);
+            }
+
+            const offer = networkReplyModel.data;
+
+            if (networkReplyModel.receiver_wallet !== wallet &&
+                networkReplyModel.receiver_identity) {
+                throw Error('Sorry not your read request');
+            }
+
+            // TODO: Only one import ID used. Later we'll support replication from multiple imports.
+            // eslint-disable-next-line
+            const importId = import_id;
+
+            const verticesPromise = this.graphStorage.findVerticesByImportId(importId);
+            const edgesPromise = this.graphStorage.findEdgesByImportId(importId);
+
+            const values = await Promise.all([verticesPromise, edgesPromise]);
+            const vertices = values[0];
+            const edges = values[1];
+
+            ImportUtilities.unpackKeys(vertices, edges);
+
+            // Get replication key and then encrypt data.
+            const holdingDataModel = await Models.holding_data.find({ where: { id: importId } });
+
+            if (!holdingDataModel) {
+                throw Error(`Didn't find import with ID. ${importId}`);
+            }
+
+            ImportUtilities.deleteInternal(vertices);
+            const holdingData = holdingDataModel.get({ plain: true });
+            const dataPublicKey = holdingData.data_public_key;
+            const replicationPrivateKey = holdingData.distribution_private_key;
+
+            Graph.decryptVertices(
+                vertices.filter(vertex => vertex.vertex_type !== 'CLASS'),
+                dataPublicKey,
+            );
+
+            /*
+            dataReadResponseObject = {
+                message: {
+                    id: REPLY_ID
+                    wallet: DH_WALLET,
+                    nodeId: KAD_ID
+                    agreementStatus: CONFIRMED/REJECTED,
+                    data_provider_wallet,
+                    encryptedData: { … }
+                },
+                messageSignature: {
+                    c: …,
+                    r: …,
+                    s: …
+               }
+            }
+             */
+
+            const dataInfo = await Models.data_info.findOne({
+                where: {
+                    import_id: importId,
+                },
+            });
+
+            if (!dataInfo) {
+                throw Error(`Failed to get data info for import ID ${importId}.`);
+            }
+
+            const replyMessage = {
+                id,
+                wallet: this.config.node_wallet,
+                nodeId: this.config.identity,
+                data_provider_wallet: dataInfo.data_provider_wallet,
+                agreementStatus: 'CONFIRMED',
+                data: {
+                    vertices,
+                    edges,
+                },
+                import_id: importId, // TODO: Temporal. Remove it.
+            };
+            const dataReadResponseObject = {
+                message: replyMessage,
+                messageSignature: Utilities.generateRsvSignature(
+                    JSON.stringify(replyMessage),
+                    this.web3,
+                    this.config.node_private_key,
+                ),
+            };
+
+            await this.network.kademlia().sendDataReadResponse(dataReadResponseObject, nodeId);
+        } catch (e) {
+            const errorMessage = `Failed to process data read request. ${e}.`;
+            this.log.warn(errorMessage);
+            this.notifyError(e);
+            await this.network.kademlia().sendDataReadResponse({
+                status: 'FAIL',
+                message: errorMessage,
+            }, nodeId);
+        }
+    }
+
+    /**
+     * Builds default command
+     * @param map
+     * @returns {{add, data: *, delay: *, deadline: *}}
+     */
+    default(map) {
+        const command = {
+            name: 'dhDataReadRequestFreeCommand',
+            transactional: true,
+        };
+        Object.assign(command, map);
+        return command;
+    }
+}
+
+module.exports = DHDataReadRequestFreeCommand;

--- a/modules/command/dh/dh-data-read-request-free-command.js
+++ b/modules/command/dh/dh-data-read-request-free-command.js
@@ -138,13 +138,15 @@ class DHDataReadRequestFreeCommand extends Command {
             await this.network.kademlia().sendDataReadResponse(dataReadResponseObject, nodeId);
         } catch (e) {
             const errorMessage = `Failed to process data read request. ${e}.`;
-            this.log.warn(errorMessage);
+            this.logger.warn(errorMessage);
             this.notifyError(e);
             await this.network.kademlia().sendDataReadResponse({
                 status: 'FAIL',
                 message: errorMessage,
             }, nodeId);
         }
+
+        return Command.empty();
     }
 
     /**

--- a/modules/command/dh/dh-read-data-location-request-command.js
+++ b/modules/command/dh/dh-read-data-location-request-command.js
@@ -65,6 +65,14 @@ class DHReadDataLocationRequestCommand extends Command {
         const nodeId = this.config.identity;
         const dataPrice = 100000; // TODO add to configuration
 
+        // TODO: Temporarily allow sending raw data (free read).
+        // Merge with all imports
+        imports.forEach((importId) => {
+            if (!replicatedImportIds.includes(importId)) {
+                replicatedImportIds.push(importId);
+            }
+        });
+
         const dataInfos = await Models.data_info.findAll({
             where: {
                 import_id: {
@@ -83,7 +91,7 @@ class DHReadDataLocationRequestCommand extends Command {
         });
 
         if (importObjects.length === 0) {
-            this.logger.warn(`Zero import size for IDs ${JSON.stringify(replicatedImportIds)}.`);
+            this.logger.trace(`Didn't find imports for query ${JSON.stringify(msgQuery)}.`);
             return Command.empty();
         }
 

--- a/modules/command/dv/dv-data-read-response-free-command.js
+++ b/modules/command/dv/dv-data-read-response-free-command.js
@@ -16,6 +16,8 @@ class DVDataReadResponseFreeCommand extends Command {
         this.web3 = ctx.web3;
         this.blockchain = ctx.blockchain;
         this.remoteControl = ctx.remoteControl;
+        this.notifyError = ctx.notifyError;
+        this.importer = ctx.importer;
     }
 
     /**

--- a/modules/command/dv/dv-data-read-response-free-command.js
+++ b/modules/command/dv/dv-data-read-response-free-command.js
@@ -1,0 +1,143 @@
+const bytes = require('utf8-length');
+
+const Models = require('../../../models/index');
+const Command = require('../command');
+const ImportUtilities = require('../../ImportUtilities');
+
+/**
+ * Handles data read response for free.
+ */
+class DVDataReadResponseFreeCommand extends Command {
+    constructor(ctx) {
+        super(ctx);
+        this.logger = ctx.logger;
+        this.config = ctx.config;
+        this.network = ctx.network;
+        this.web3 = ctx.web3;
+        this.remoteControl = ctx.remoteControl;
+    }
+
+    /**
+     * Executes command and produces one or more events
+     * @param command
+     * @param transaction
+     */
+    async execute(command, transaction) {
+        const {
+            message,
+        } = command.data;
+
+
+        /*
+            message: {
+                id: REPLY_ID
+                wallet: DH_WALLET,
+                data_provider_wallet: DC_WALLET,
+                nodeId: KAD_ID
+                agreementStatus: CONFIRMED/REJECTED,
+                data: { … }
+                importId: IMPORT_ID,        // Temporal. Remove it.
+            },
+         */
+
+        // Is it the chosen one?
+        const replyId = message.id;
+        const {
+            import_id: importId,
+            data_provider_wallet: dcWallet,
+            wallet: dhWallet,
+        } = message;
+
+        // Find the particular reply.
+        const networkQueryResponse = await Models.network_query_responses.findOne({
+            where: { reply_id: replyId },
+        });
+
+        if (!networkQueryResponse) {
+            throw Error(`Didn't find query reply with ID ${replyId}.`);
+        }
+
+        const networkQuery = await Models.network_queries.findOne({
+            where: { id: networkQueryResponse.query_id },
+        });
+
+        if (message.agreementStatus !== 'CONFIRMED') {
+            networkQuery.status = 'REJECTED';
+            await networkQuery.save({ fields: ['status'] });
+            throw Error('Read not confirmed');
+        }
+
+        // Calculate root hash and check is it the same on the SC.
+        const { vertices, edges } = message.data;
+
+        const fingerprint = await this.blockchain.getRootHash(dcWallet, importId);
+
+        if (!fingerprint) {
+            const errorMessage = `Couldn't not find fingerprint for Dc ${dcWallet} and import ID ${importId}`;
+            this.log.warn(errorMessage);
+            networkQuery.status = 'FAILED';
+            await networkQuery.save({ fields: ['status'] });
+            throw errorMessage;
+        }
+
+        const merkle = await ImportUtilities.merkleStructure(vertices.filter(vertex =>
+            vertex.vertex_type !== 'CLASS'), edges);
+        const rootHash = merkle.tree.getRoot();
+
+        if (fingerprint !== rootHash) {
+            const errorMessage = `Fingerprint root hash doesn't match with one from data. Root hash ${rootHash}, first DH ${dhWallet}, import ID ${importId}`;
+            this.log.warn(errorMessage);
+            networkQuery.status = 'FAILED';
+            await networkQuery.save({ fields: ['status'] });
+            throw errorMessage;
+        }
+
+        try {
+            await this.importer.importJSON({
+                vertices: message.data.vertices,
+                edges: message.data.edges,
+                import_id: importId,
+                wallet: dcWallet,
+            }, true);
+        } catch (error) {
+            this.log.warn(`Failed to import JSON. ${error}.`);
+            this.notifyError(error);
+            networkQuery.status = 'FAILED';
+            await networkQuery.save({ fields: ['status'] });
+            return;
+        }
+
+        this.log.info(`Import ID ${importId} imported successfully.`);
+        this.remoteControl.readNotification(`Import ID ${importId} imported successfully.`);
+
+        const dataSize = bytes(JSON.stringify(vertices));
+        await Models.data_info.create({
+            import_id: importId,
+            total_documents: vertices.length,
+            root_hash: rootHash,
+            data_provider_wallet: dcWallet,
+            import_timestamp: new Date(),
+            data_size: dataSize,
+        });
+
+        return Command.empty();
+    }
+
+    /**
+     * Builds default DVDataReadRequestCommand
+     * @param map
+     * @returns {{add, data: *, delay: *, deadline: *}}
+     */
+    default(map) {
+        const command = {
+            name: 'dvDataReadResponseFreeCommand',
+            delay: 0,
+            deadline_at: Date.now() + (5 * 60 * 1000),
+            transactional: false,
+        };
+        Object.assign(command, map);
+        return command;
+    }
+}
+
+module.exports = DVDataReadResponseFreeCommand;

--- a/modules/command/dv/dv-data-read-response-free-command.js
+++ b/modules/command/dv/dv-data-read-response-free-command.js
@@ -14,6 +14,7 @@ class DVDataReadResponseFreeCommand extends Command {
         this.config = ctx.config;
         this.network = ctx.network;
         this.web3 = ctx.web3;
+        this.blockchain = ctx.blockchain;
         this.remoteControl = ctx.remoteControl;
     }
 
@@ -74,7 +75,7 @@ class DVDataReadResponseFreeCommand extends Command {
 
         if (!fingerprint) {
             const errorMessage = `Couldn't not find fingerprint for Dc ${dcWallet} and import ID ${importId}`;
-            this.log.warn(errorMessage);
+            this.logger.warn(errorMessage);
             networkQuery.status = 'FAILED';
             await networkQuery.save({ fields: ['status'] });
             throw errorMessage;
@@ -86,7 +87,7 @@ class DVDataReadResponseFreeCommand extends Command {
 
         if (fingerprint !== rootHash) {
             const errorMessage = `Fingerprint root hash doesn't match with one from data. Root hash ${rootHash}, first DH ${dhWallet}, import ID ${importId}`;
-            this.log.warn(errorMessage);
+            this.logger.warn(errorMessage);
             networkQuery.status = 'FAILED';
             await networkQuery.save({ fields: ['status'] });
             throw errorMessage;
@@ -100,14 +101,14 @@ class DVDataReadResponseFreeCommand extends Command {
                 wallet: dcWallet,
             }, true);
         } catch (error) {
-            this.log.warn(`Failed to import JSON. ${error}.`);
+            this.logger.warn(`Failed to import JSON. ${error}.`);
             this.notifyError(error);
             networkQuery.status = 'FAILED';
             await networkQuery.save({ fields: ['status'] });
-            return;
+            return Command.empty();
         }
 
-        this.log.info(`Import ID ${importId} imported successfully.`);
+        this.logger.info(`Import ID ${importId} imported successfully.`);
         this.remoteControl.readNotification(`Import ID ${importId} imported successfully.`);
 
         const dataSize = bytes(JSON.stringify(vertices));

--- a/modules/controller/dh-controller.js
+++ b/modules/controller/dh-controller.js
@@ -86,6 +86,21 @@ class DHController {
             },
         });
     }
+
+    /**
+     * Sends dhDataReadRequestFreeCommand to the queue.
+     * @param message Message received from network
+     * @returns {Promise<void>}
+     */
+    async handleDataReadRequestFree(message) {
+        await this.commandExecutor.add({
+            name: 'dhDataReadRequestFreeCommand',
+            transactional: false,
+            data: {
+                message,
+            },
+        });
+    }
 }
 
 module.exports = DHController;

--- a/modules/controller/dv-controller.js
+++ b/modules/controller/dv-controller.js
@@ -99,6 +99,42 @@ class DVController {
             transactional: false,
         });
     }
+    async handleDataReadResponseFree(message) {
+        /*
+            message: {
+                id: REPLY_ID
+                wallet: DH_WALLET,
+                nodeId: KAD_ID
+                agreementStatus: CONFIRMED/REJECTED,
+                encryptedData: { … }
+                importId: IMPORT_ID,        // Temporal. Remove it.
+            },
+         */
+
+        // Is it the chosen one?
+        const replyId = message.id;
+
+        // Find the particular reply.
+        const networkQueryResponse = await Models.network_query_responses.findOne({
+            where: { reply_id: replyId },
+        });
+
+        if (!networkQueryResponse) {
+            throw Error(`Didn't find query reply with ID ${replyId}.`);
+        }
+
+        const networkQuery = await Models.network_queries.findOne({
+            where: { id: networkQueryResponse.query_id },
+        });
+        await this.commandExecutor.add({
+            name: 'dvDataReadResponseFreeCommand',
+            delay: 0,
+            data: {
+                message,
+            },
+            transactional: false,
+        });
+    }
 }
 
 module.exports = DVController;

--- a/modules/importer.js
+++ b/modules/importer.js
@@ -144,7 +144,8 @@ class Importer {
 
         edges = Graph.sortVertices(edges);
         vertices = Graph.sortVertices(vertices);
-        const merkle = await ImportUtilities.merkleStructure(vertices, edges);
+        const merkle = await ImportUtilities.merkleStructure(vertices.filter(vertex =>
+            vertex.vertex_type !== 'CLASS'), edges);
 
         this.log.info(`Import id: ${import_id}`);
         this.log.info(`Import hash: ${merkle.tree.getRoot()}`);

--- a/ot-node.js
+++ b/ot-node.js
@@ -415,6 +415,7 @@ class OTNode {
             remoteControl: awilix.asClass(RemoteControl).singleton(),
             logger: awilix.asValue(log),
             networkUtilities: awilix.asClass(NetworkUtilities).singleton(),
+            notifyError: awilix.asFunction(() => notifyBugsnag).transient(),
         });
 
         const network = container.resolve('network');


### PR DESCRIPTION
Enable purchasing of imports free of charge. No contracts will be involved into getting data from nodes. For that purpose two command-actions added in order to override regular flow.
Additional:
- Fixed calculating root-hash when importing data via API.
- Added missing `notifyError` functions to the container used by bootstrap node.