### PR TITLE
Prevent sorting with _dc_key during DH replication

### DIFF
--- a/modules/command/dh/dh-offer-replication-parameters-command.js
+++ b/modules/command/dh/dh-offer-replication-parameters-command.js
@@ -30,7 +30,7 @@ class DHOfferReplicationParametersCommand extends Command {
         } = command.data;
 
         const encryptedVertices = importResult.vertices.filter(vertex => vertex.vertex_type !== 'CLASS');
-        ImportUtilities.sort(encryptedVertices, '_dc_key');
+        ImportUtilities.sort(encryptedVertices);
         const litigationBlocks = Challenge.getBlocks(encryptedVertices, 32);
         const litigationBlocksMerkleTree = new MerkleTree(litigationBlocks);
         const litigationRootHash = litigationBlocksMerkleTree.getRoot();


### PR DESCRIPTION
Prevent sorting vertices with `_dc_key` during DH replication due to the side effects. At that time vertices do not have '_dc_key' field.