### PR TITLE
Support SSL for API routes

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -531,7 +531,7 @@ class OTNode {
      * Start RPC server
      */
     startRPC(emitter) {
-        const server = restify.createServer({
+        const options = {
             name: 'RPC server',
             version: pjson.version,
             formatters: {
@@ -566,7 +566,17 @@ class OTNode {
                     return data;
                 },
             },
-        });
+        };
+
+        if (config.node_rpc_use_ssl !== '0') {
+            Object.assign(options, {
+                key: fs.readFileSync(config.node_rpc_ssl_key_path),
+                certificate: fs.readFileSync(config.node_rpc_ssl_cert_path),
+                rejectUnauthorized: true,
+            });
+        }
+
+        const server = restify.createServer(options);
 
         server.use(restify.plugins.acceptParser(server.acceptable));
         server.use(restify.plugins.queryParser());
@@ -610,7 +620,7 @@ class OTNode {
                 return true;
             }
 
-            if (!remote_access.includes(request_ip)) {
+            if (remote_access.length > 0 && !remote_access.includes(request_ip)) {
                 res.status(403);
                 res.send({
                     message: 'Unauthorized request',

--- a/seeders/20180407124949-node-config.js
+++ b/seeders/20180407124949-node-config.js
@@ -130,6 +130,18 @@ module.exports = {
         value: process.env.NODE_RPC_PORT ? process.env.NODE_RPC_PORT : '8900',
     },
     {
+        key: 'node_rpc_use_ssl',
+        value: process.env.NODE_RPC_USE_SSL ? process.env.NODE_RPC_USE_SSL : '0',
+    },
+    {
+        key: 'node_rpc_ssl_key_path',
+        value: process.env.NODE_RPC_SSL_KEY_PATH ? process.env.NODE_RPC_SSL_KEY_PATH : '',
+    },
+    {
+        key: 'node_rpc_ssl_cert_path',
+        value: process.env.NODE_RPC_SSL_CERT_PATH ? process.env.NODE_RPC_SSL_CERT_PATH : '',
+    },
+    {
         key: 'send_logs_to_origintrail',
         value: process.env.SEND_LOGS ? process.env.SEND_LOGS : '1',
     },

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -32,7 +32,7 @@ describe('Utilities module', () => {
                 'read_stake_factor', 'dh_max_time_mins', 'dh_price', 'dh_stake_factor', 'send_logs_to_origintrail',
                 'dh_min_reputation', 'dh_min_stake_amount', 'max_token_amount_per_dh', 'total_escrow_time_in_milliseconds',
                 'is_bootstrap_node', 'houston_password', 'enable_debug_logs_level', 'reverse_tunnel_address', 'reverse_tunnel_port',
-                'network_id'],
+                'network_id', 'node_rpc_use_ssl', 'node_rpc_ssl_key_path', 'node_rpc_ssl_cert_path'],
             'Some config items are missing in node_config',
         );
     });


### PR DESCRIPTION
Add support for SSL for all API routes.
Following new variables added to support this feature:
- _**node_rpc_use_ssl**_ set to '1' if server should use SSL feature.
- _**node_rpc_ssl_key_path**_ set path to the SSL key path.
- _**node_rpc_ssl_cert_path**_ set path to the SSL certificate path.