### PR TITLE
Suppress bugsnag info messages

### DIFF
--- a/ot-node.js
+++ b/ot-node.js
@@ -222,6 +222,7 @@ class OTNode {
                         warn: log.warn,
                         error: log.error,
                     },
+                    logLevel: 'error',
                 },
             );
         }


### PR DESCRIPTION
Suppress bugsnag info messages. Usually bugsnag will dump large JSON before pushing it to the server. 