### PR TITLE
Add bidding fallback

### DIFF
--- a/modules/command/command-executor.js
+++ b/modules/command/command-executor.js
@@ -126,7 +126,7 @@ class CommandExecutor {
             }
         } catch (e) {
             this.logger.error(`Failed to process command ${command.name} and ID ${command.id}. ${e}.\n${e.stack}`);
-            this.notifyError(e);
+            this.notifyError(e, { data: command.data });
             try {
                 const result = await this._handleError(command, handler, e);
                 if (result && result.commands) {

--- a/ot-node.js
+++ b/ot-node.js
@@ -106,7 +106,7 @@ process.on('exit', (code) => {
     }
 });
 
-function notifyBugsnag(error, subsystem) {
+function notifyBugsnag(error, metadata, subsystem) {
     if (process.env.NODE_ENV !== 'development') {
         const cleanConfig = Object.assign({}, config);
         delete cleanConfig.node_private_key;
@@ -126,6 +126,10 @@ function notifyBugsnag(error, subsystem) {
             options.subsystem = {
                 name: subsystem,
             };
+        }
+
+        if (metadata) {
+            Object.assign(options, metadata);
         }
 
         bugsnag.notify(error, options);


### PR DESCRIPTION
Add fallback action for when addBid() fails. First check if bid was already finished and state that node was to late with its bid.