### PR TITLE
Peer cache cleanup [Delivers #159887837]

### DIFF
--- a/modules/kademlia/peer-cache.js
+++ b/modules/kademlia/peer-cache.js
@@ -11,13 +11,18 @@ class PeerCache {
         this.db = new Datastore({ filename: peerCacheFilePath, autoload: true });
         this.db.persistence.setAutocompactionInterval(10000);
 
-        this.node.router.events.on('add', (identity) => {
-            this.node.logger.debug(`updating peer profile ${identity}`);
+        this.node.router.events.on('add', async (identity) => {
+            this.node.logger.trace(`updating peer profile ${identity}`);
             const contact = this.node.router.getContactByNodeId(identity);
             if (contact != null) {
                 contact.timestamp = Date.now();
-                this._setExternalPeerInfo(identity, contact);
+                await this._setExternalPeerInfo(identity, contact);
             }
+        });
+
+        this.node.router.events.on('remove', async (identity) => {
+            this.node.logger.trace(`updating peer profile ${identity}`);
+            await this._removeExternalPeerInfo(identity);
         });
     }
 
@@ -74,6 +79,32 @@ class PeerCache {
     }
 
     /**
+     * Removes contact from peer cache per identity
+     * @param identity
+     * @returns {Promise}
+     * @private
+     */
+    _removeExternalPeerInfo(identity) {
+        return new Promise((resolve, reject) => {
+            this.db.remove(
+                {
+                    _id: identity,
+                },
+                {},
+                (err, num) => {
+                    if (err) {
+                        this.node.logger.error(`Failed to remove ${identity} from peercache`);
+                        reject(err);
+                    } else {
+                        this.node.logger.debug(`Contact ${identity} removed from peercache`);
+                        resolve(num);
+                    }
+                },
+            );
+        });
+    }
+
+    /**
      * Returns a list of bootstrap nodes from local profiles
      * @returns {string[]} urls
      */
@@ -91,6 +122,29 @@ class PeerCache {
                 }
             });
         });
+    }
+
+    /**
+     * Get size of the peercache
+     * @returns {Promise}
+     */
+    getSize() {
+        return new Promise((resolve, reject) => {
+            this.db.count({}, (err, count) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(count);
+                }
+            });
+        });
+    }
+
+    /**
+     * Closes the database
+     */
+    close() {
+        this.db.persistence.stopAutocompaction();
     }
 }
 

--- a/test/modules/peercache.test.js
+++ b/test/modules/peercache.test.js
@@ -108,12 +108,12 @@ describe('Peercache basic tests', () => {
                     promises.push(peercache._setExternalPeerInfo(id, dummyContact));
                 }
 
-                Promise.all(promises);
+                await Promise.all(promises);
 
                 let size = await peercache.getSize();
                 assert.equal(size, 10, 'There should be 10 contacts in peercache');
 
-                Promise.all(ids.map(id => peercache._removeExternalPeerInfo(id)));
+                await Promise.all(ids.map(id => peercache._removeExternalPeerInfo(id)));
 
                 size = await peercache.getSize();
                 assert.equal(size, 0, 'There should be zero contacts in peercache');

--- a/test/modules/peercache.test.js
+++ b/test/modules/peercache.test.js
@@ -1,0 +1,147 @@
+require('dotenv').config();
+const {
+    describe, beforeEach, afterEach, it,
+} = require('mocha');
+const { assert } = require('chai');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const uuidv4 = require('uuid/v4');
+const Utilities = require('../../modules/Utilities');
+const PeerCache = require('../../modules/kademlia/peer-cache');
+
+const logger = Utilities.getLogger();
+
+/**
+ * Dummy contact for testing purposes
+ * @type {{hostname: string, protocol: string, port: number}}
+ */
+const dummyContact = {
+    hostname: 'localhost',
+    protocol: 'https:',
+    port: 5182,
+};
+
+/**
+ * Simple Kademlia node mock
+ */
+class NodeMock {
+    constructor() {
+        this.handlers = {};
+        this.router = {
+            events: {
+                on: (event, callback) => {
+                    this.handlers[event] = callback;
+                },
+            },
+
+            getContactByNodeId() {
+                return dummyContact;
+            },
+        };
+        this.logger = logger;
+    }
+
+    /**
+     * Fire single event (add/remove)
+     * @param event
+     * @param identity
+     */
+    fire(event, identity) {
+        this.handlers[event](identity);
+    }
+}
+
+describe('Peercache basic tests', () => {
+    let peercache;
+    const nodeMock = new NodeMock();
+    const peercachePath = `${path.join(os.tmpdir(), 'test.db')}`;
+
+    beforeEach('Setup DB', async () => {
+        const fn = PeerCache(`${peercachePath}`);
+        peercache = fn(nodeMock);
+        logger.debug(`Peercache db created on ${peercachePath}`);
+    });
+
+    describe('Test one contact insertion', () => {
+        it(
+            'should correctly add a contact',
+            // eslint-disable-next-line no-loop-func
+            async () => {
+                await peercache._setExternalPeerInfo(uuidv4(), dummyContact);
+
+                const size = await peercache.getSize();
+                assert.equal(size, 1, 'There should be just one contact in peercache');
+            },
+        );
+    });
+
+    describe('Test one contact insertion and deletion', () => {
+        it(
+            'should correctly add a contact and remove the same one',
+            // eslint-disable-next-line no-loop-func
+            async () => {
+                const id = uuidv4();
+                await peercache._setExternalPeerInfo(id, dummyContact);
+
+                let size = await peercache.getSize();
+                assert.equal(size, 1, 'There should be just one contact in peercache');
+
+                await peercache._removeExternalPeerInfo(id);
+
+                size = await peercache.getSize();
+                assert.equal(size, 0, 'There should be zero contacts in peercache');
+            },
+        );
+    });
+
+    describe('Test many contacts insertion and deletion', () => {
+        it(
+            'should correctly add many contacts and remove them all',
+            // eslint-disable-next-line no-loop-func
+            async () => {
+                const ids = [];
+                const promises = [];
+                for (let i = 0; i < 10; i += 1) {
+                    const id = uuidv4();
+                    ids.push(id);
+                    promises.push(peercache._setExternalPeerInfo(id, dummyContact));
+                }
+
+                Promise.all(promises);
+
+                let size = await peercache.getSize();
+                assert.equal(size, 10, 'There should be 10 contacts in peercache');
+
+                Promise.all(ids.map(id => peercache._removeExternalPeerInfo(id)));
+
+                size = await peercache.getSize();
+                assert.equal(size, 0, 'There should be zero contacts in peercache');
+            },
+        );
+    });
+
+    describe('Test node event handler hooks', () => {
+        it(
+            'should correctly add a contact and remove the same one',
+            // eslint-disable-next-line no-loop-func
+            async () => {
+                const id = uuidv4();
+                nodeMock.fire('add', id);
+
+                let size = await peercache.getSize();
+                assert.equal(size, 1, 'There should be just one contact in peercache');
+
+                nodeMock.fire('remove', id);
+
+                size = await peercache.getSize();
+                assert.equal(size, 0, 'There should be zero contacts in peercache');
+            },
+        );
+    });
+
+    afterEach('Drop DB', () => {
+        peercache.close();
+        fs.unlinkSync(peercachePath);
+    });
+});


### PR DESCRIPTION
- remove contact from cache on Kadence node `remove` event
- skip looking at cache if peer is not in the bucket (decrease noise)
- add unit test