### PR TITLE
Handle failed transactions (#160412782)

### DIFF
--- a/modules/Blockchain/Ethereum/Transactions.js
+++ b/modules/Blockchain/Ethereum/Transactions.js
@@ -4,6 +4,7 @@ const Queue = require('better-queue');
 const sleep = require('sleep-async')().Promise;
 const BN = require('bn.js');
 const Utilities = require('../../Utilities.js');
+const { TransactionFailedError } = require('../../errors');
 
 class Transactions {
     /**
@@ -21,6 +22,7 @@ class Transactions {
 
         this.queue = new Queue((async (args, cb) => {
             const { transaction, future } = args;
+            let transactionHandled = false;
             try {
                 for (let i = 0; i < 3; i += 1) {
                     try {
@@ -28,13 +30,18 @@ class Transactions {
                         const result = await this._sendTransaction(transaction);
                         if (result.status === '0x0') {
                             future.reject(result);
+                            transactionHandled = true;
                             break;
                         } else {
                             future.resolve(result);
+                            transactionHandled = true;
                             break;
                         }
                     } catch (error) {
-                        if (!error.toString().includes('nonce too low') && !error.toString().includes('underpriced')) {
+                        if (!error.toString().includes('nonce too low') && !error.toString().includes('underpriced') &&
+                            // Ganache's version of nonce error.
+                            error.name !== 'TXRejectedError' && !error.includes('the tx doesn\'t have the correct nonce.')
+                        ) {
                             throw new Error(error);
                         }
 
@@ -45,9 +52,15 @@ class Transactions {
                 }
             } catch (e) {
                 future.reject(e);
+                return;
             }
-            this.lastTransactionTime = Date.now();
-            cb();
+
+            if (transactionHandled) {
+                this.lastTransactionTime = Date.now();
+                cb();
+            } else {
+                future.reject(new TransactionFailedError('Transaction failed', transaction));
+            }
         }), { concurrent: 1 });
     }
 

--- a/modules/errors/index.js
+++ b/modules/errors/index.js
@@ -1,2 +1,4 @@
 
 module.exports.NetworkRequestIgnoredError = require('./network-request-ignored-error');
+
+module.exports.TransactionFailedError = require('./transaction-failed-error');

--- a/modules/errors/transaction-failed-error.js
+++ b/modules/errors/transaction-failed-error.js
@@ -1,0 +1,19 @@
+/**
+ * Represent one failed transaction on a blockchain. Should be used
+ * after a number of failed attempts.
+ */
+class TransactionFailedError extends Error {
+    constructor(message, transaction) {
+        super(message);
+
+        // Ensure the name of this error is the same as the class name
+        this.name = this.constructor.name;
+
+        this.transaction = transaction;
+
+        // This clips the constructor invocation from the stack trace.
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+module.exports = TransactionFailedError;


### PR DESCRIPTION
Handle failed transactions that were unable to be sent 3 times due to the 'nonce too low' or 'transaction underpriced'.