### PR TITLE
Docker fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,4 +15,4 @@ node.log
 modules/blockchain_interface/ethereum/build/*
 modules/Blockchain/Ethereum/build/
 hidden_service
-/modules/Database/system.db
+modules/Database/system.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+.DS_Store
+.idea
+.vscode/*
+.env
+.nyc_output
+.git
+.origintrail-noderc
+node_modules
+keys
+data
+importers
+# postman
+# test
+node.log
+modules/blockchain_interface/ethereum/build/*
+modules/Blockchain/Ethereum/build/
+hidden_service
+/modules/Database/system.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
 RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=./generatedConfig/.origintrail-noderc
-RUN ls -al generatedConfig/*
+RUN ls -al /ot-node/generatedConfig/* || true
 COPY generatedConfig/.origintrail-noderc/ /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN ls -al /ot-node/
 RUN find /ot-node -name system.db
 RUN find / -name system.db
 RUN ls -al /root
-COPY --from=build /root/.origintrail-noderc /root/
+COPY /root/.origintrail-noderc/ /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,10 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup && ls -al /root
-RUN ls -al ./modules/Database/
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
+RUN ls -al /ot-node/modules/Database/
+RUN find /ot-node -name system.db
+RUN find / -name system.db
 ADD /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup && RUN ls -al /root
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup && ls -al /root
 RUN ls -al ./modules/Database/
 ADD /root/.origintrail-noderc /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,12 @@ RUN mkdir -p /var/log/supervisor
 COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add files
+RUN ls -al
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
 RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=./generatedConfig/.origintrail-noderc
 RUN ls -al /ot-node/generatedConfig/* || true
+RUN find / -name generatedConfig
 COPY generatedConfig/.origintrail-noderc/ /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
 RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
-RUN ls -al /ot-node/modules/Database/
+RUN ls -al /ot-node/
 RUN find /ot-node -name system.db
 RUN find / -name system.db
+RUN ls -al /root
 ADD /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
-COPY /root/.origintrail-noderc /root/
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=$(pwd)/../.origintrail-noderc
+COPY /.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:16.04
 MAINTAINER OriginTrail
 LABEL maintainer="OriginTrail"
-ARG targetEnvironment=staging
+ARG targetEnvironment=production
 
 ENV NODE_ENV=$targetEnvironment
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=$(pwd)/generatedConfig/.origintrail-noderc
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=./generatedConfig/.origintrail-noderc
 RUN ls -al generatedConfig/*
 COPY generatedConfig/.origintrail-noderc/ /root/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=$(pwd)/../.origintrail-noderc
-COPY /.origintrail-noderc /root/
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
+RUN ls -al /root
+ADD /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM ubuntu:16.04
 MAINTAINER OriginTrail
 LABEL maintainer="OriginTrail"
 ARG targetEnvironment=staging
-VOLUME /ot-node /var/lib/arangodb
 
 ENV NODE_ENV=$targetEnvironment
 
@@ -34,5 +33,6 @@ ADD testnet/papertrail.yml /etc/log_files.yml
 WORKDIR /ot-node
 RUN chmod 400 testnet/start.sh
 
+VOLUME /ot-node /var/lib/arangodb
 EXPOSE 5278 8900 3000 3010
 CMD ["sh", "/ot-node/testnet/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN ls -al /ot-node/
 RUN find /ot-node -name system.db
 RUN find / -name system.db
 RUN ls -al /root
-ADD /root/.origintrail-noderc /root/
+COPY --from=build /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
-RUN ls -al /root
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup && RUN ls -al /root
+RUN ls -al ./modules/Database/
 ADD /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 #base image
 FROM ubuntu:16.04
 MAINTAINER OriginTrail
+LABEL maintainer="OriginTrail"
+ARG targetEnvironment=staging
+VOLUME /ot-node /var/lib/arangodb
 
-ENV NODE_ENV=staging
+ENV NODE_ENV=$targetEnvironment
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_9.x |  bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add files
 COPY . /ot-node
-COPY /root/ /root
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
 RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
+COPY /root/.origintrail-noderc /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,9 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
-RUN ls -al /ot-node/
-RUN find /ot-node -name system.db
-RUN find / -name system.db
-RUN ls -al /root
-COPY /root/.origintrail-noderc/ /root/
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=$(pwd)/generatedConfig/.origintrail-noderc
+RUN ls -al generatedConfig/*
+COPY generatedConfig/.origintrail-noderc/ /root/
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Add files
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
-RUN ls /root/.origintrail-noderc
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=/ot-node/data
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add files
 COPY . /ot-node
+COPY /root/ /root
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
 RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,10 @@ RUN mkdir -p /var/log/supervisor
 COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add files
-RUN ls -al
 COPY . /ot-node
 RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
-RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=./generatedConfig/.origintrail-noderc
-RUN ls -al /ot-node/generatedConfig/* || true
-RUN find / -name generatedConfig
-COPY generatedConfig/.origintrail-noderc/ /root/
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup
+RUN ls /root/.origintrail-noderc
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,8 +1,10 @@
 #base image
 FROM ubuntu:16.04
 MAINTAINER OriginTrail
+LABEL maintainer="OriginTrail"
+ARG targetEnvironment=development
 
-ENV NODE_ENV=development
+ENV NODE_ENV=$targetEnvironment
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_9.x |  bash -
@@ -19,25 +21,18 @@ RUN apt-get update && apt install -y -qq supervisor
 RUN mkdir -p /var/log/supervisor
 COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-COPY package.json /tmp/package.json
-RUN cd /tmp && npm install
+# Add files
+COPY . /ot-node
+RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=/ot-node/data
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
-
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin
 ADD testnet/papertrail.yml /etc/log_files.yml
 
-#Clone the project
-RUN wget -O ot-node.zip https://codeload.github.com/OriginTrail/ot-node/zip/development
-RUN unzip ot-node.zip -d . && rm ot-node.zip && mv ot-node-development ot-node
-
-RUN cp -a /tmp/node_modules /ot-node
-
 WORKDIR /ot-node
-RUN mkdir keys data &> /dev/null
-RUN cp .env.example .env
-COPY testnet/start.sh /ot-node/testnet/start.sh
 RUN chmod 400 testnet/start.sh
 
+VOLUME /ot-node /var/lib/arangodb
 EXPOSE 5278 8900 3000 3010
 CMD ["sh", "/ot-node/testnet/start.sh"]

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -1,8 +1,10 @@
 #base image
 FROM ubuntu:16.04
 MAINTAINER OriginTrail
+LABEL maintainer="OriginTrail"
+ARG targetEnvironment=stable
 
-ENV NODE_ENV=stable
+ENV NODE_ENV=$targetEnvironment
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_9.x |  bash -
@@ -19,25 +21,18 @@ RUN apt-get update && apt install -y -qq supervisor
 RUN mkdir -p /var/log/supervisor
 COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-COPY package.json /tmp/package.json
-RUN cd /tmp && npm install
+# Add files
+COPY . /ot-node
+RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=/ot-node/data
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
-
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin
 ADD testnet/papertrail.yml /etc/log_files.yml
 
-#Clone the project
-RUN wget -O ot-node.zip https://codeload.github.com/OriginTrail/ot-node/zip/release/stable
-RUN unzip ot-node.zip -d . && rm ot-node.zip && mv ot-node-release-stable ot-node
-
-RUN cp -a /tmp/node_modules /ot-node
-
 WORKDIR /ot-node
-RUN mkdir keys data &> /dev/null
-RUN cp .env.example .env
-COPY testnet/start.sh /ot-node/testnet/start.sh
 RUN chmod 400 testnet/start.sh
 
+VOLUME /ot-node /var/lib/arangodb
 EXPOSE 5278 8900 3000 3010
 CMD ["sh", "/ot-node/testnet/start.sh"]

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,8 +1,10 @@
 #base image
 FROM ubuntu:16.04
 MAINTAINER OriginTrail
+LABEL maintainer="OriginTrail"
+ARG targetEnvironment=staging
 
-ENV NODE_ENV=staging
+ENV NODE_ENV=$targetEnvironment
 
 RUN apt-get -qq update && apt-get -qq -y install curl
 RUN curl -sL https://deb.nodesource.com/setup_9.x |  bash -
@@ -19,25 +21,18 @@ RUN apt-get update && apt install -y -qq supervisor
 RUN mkdir -p /var/log/supervisor
 COPY testnet/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
-COPY package.json /tmp/package.json
-RUN cd /tmp && npm install
+# Add files
+COPY . /ot-node
+RUN  echo '{ "database": { "password": "root" }}' > /ot-node/.origintrail-noderc
+RUN service arangodb3 start && cd /ot-node && npm install && npm run setup -- --configDir=/ot-node/data
 
 RUN wget https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote_syslog_linux_amd64.tar.gz
-
 RUN tar xzf ./remote_syslog_linux_amd64.tar.gz && cd remote_syslog && cp ./remote_syslog /usr/local/bin
 ADD testnet/papertrail.yml /etc/log_files.yml
 
-#Clone the project
-RUN wget -O ot-node.zip https://codeload.github.com/OriginTrail/ot-node/zip/release/staging
-RUN unzip ot-node.zip -d . && rm ot-node.zip && mv ot-node-release-staging ot-node
-
-RUN cp -a /tmp/node_modules /ot-node
-
 WORKDIR /ot-node
-RUN mkdir keys data &> /dev/null
-RUN cp .env.example .env
-COPY testnet/start.sh /ot-node/testnet/start.sh
 RUN chmod 400 testnet/start.sh
 
+VOLUME /ot-node /var/lib/arangodb
 EXPOSE 5278 8900 3000 3010
 CMD ["sh", "/ot-node/testnet/start.sh"]

--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -126,7 +126,7 @@ class RegisterNode {
 
     setConfig() {
         return new Promise(async (resolve, reject) => {
-            if (!process.env.NODE_WALLET) {
+            if (!localConfiguration.node_wallet) {
                 const { wallet, pk } = await this.generateWallet();
                 localConfiguration.node_wallet = wallet;
                 localConfiguration.node_private_key = pk;
@@ -143,7 +143,7 @@ class RegisterNode {
                 localConfiguration.node_ip = ip.address();
             }
 
-            console.log(JSON.stringify(localConfiguration));
+            console.log(JSON.stringify(localConfiguration, null, 4));
 
             fs.writeFile(`.${pjson.name}rc`, JSON.stringify(localConfiguration), (err) => {
                 if (fs.existsSync(dbPath)) {

--- a/testnet/supervisord.conf
+++ b/testnet/supervisord.conf
@@ -4,7 +4,7 @@ logfile=/dev/null
 logfile_maxbytes=0
 
 [program:otnode]
-command=bash -c "node /ot-node/testnet/register-node.js | tee -a complete-node.log"
+command=bash -c "node /ot-node/testnet/register-node.js --configDir=/ot-node/data/ | tee -a complete-node.log"
 redirect_stderr=true
 autorestart=true
 stdout_logfile=/dev/fd/1


### PR DESCRIPTION
Complete rework of the Docker image building. This change fixes problem introduced in v1.4.0.

Changes:
- Local files from Docker context are used to wrap-up docker image. 
This particularly means that running `docker build .` will use local files and not fetch one form the Github. Also, all images built in the cloud are build with code that triggered that build.
- Added volumes during build phase. 
No need to specify mount points during container initialization.
- Container use new 'config' features and now passing variables to the node require having 'origintrail-node_' prefix. For example:
```
docker run -it --name=otnodelocal -p 8900:8900 -p 5278:5278 -p 3000:3000 -e INSTALLATION=local -e origintrail-node_traverse_nat_enabled=true d925255190cd
```