### PR TITLE
Use more difficulty in Identities and network communication

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -130,7 +130,6 @@
     "control_sock_enabled": false,
     "control_sock": 12000,
     "onion_enabled": false,
-    "test_network": true,
     "ssl_authority_paths": [],
     "send_logs_to_origintrail": false,
     "enable_debug_logs_level": false,

--- a/config/config.json
+++ b/config/config.json
@@ -78,7 +78,7 @@
       "id": "Devnet",
       "bootstraps": ["https://46.101.38.216:5278/#d0fe3f2c8c3868f3c88f1647243d4b770eb057ea"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
-      "solutionDifficulty": 20,
+      "solutionDifficulty": 8,
       "identityDifficulty": 8
     },
     "bugSnag": {
@@ -179,7 +179,7 @@
       "id": "StagenetV1.0.0",
       "bootstraps": ["https://188.166.3.182:5278/#2fee0c13ad5d2e4a6a90ce9f20a07720edbd0a41"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
-      "solutionDifficulty": 20,
+      "solutionDifficulty": 8,
       "identityDifficulty": 14
     },
     "bugSnag": {
@@ -279,7 +279,7 @@
       "id": "StablenetV1.0.0",
       "bootstraps": ["https://82.196.10.12:5278/#ca87147a501adf39eaa648c2b09735559ee3511d"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
-      "solutionDifficulty": 20,
+      "solutionDifficulty": 8,
       "identityDifficulty": 14
     },
     "bugSnag": {
@@ -379,7 +379,7 @@
       "id": "PirotV1.0.0",
       "bootstraps": ["https://46.101.38.216:5278/#d0fe3f2c8c3868f3c88f1647243d4b770eb057ea"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
-      "solutionDifficulty": 20,
+      "solutionDifficulty": 8,
       "identityDifficulty": 14
     },
     "bugSnag": {

--- a/config/config.json
+++ b/config/config.json
@@ -8,7 +8,6 @@
     "node_rpc_port": 8900,
     "remote_control_enabled": true,
     "node_remote_control_port": 3000,
-    "test_network_enabled": true,
     "is_bootstrap_node": false,
     "send_logs": false,
     "logs_level_debug": true,
@@ -19,7 +18,7 @@
     "ssl_certificate_path": "kademlia.crt",
     "identity_filepath": "identity.json",
     "erc725_identity_filepath": "erc725_identity.json",
-    "cpus": 1,
+    "cpus": 0,
     "embedded_wallet_directory": "wallet.dat",
     "embedded_peercache_path": "peercache",
     "onion_virtual_port": "4043",
@@ -31,7 +30,6 @@
     "control_sock_enabled": false,
     "control_sock": 12000,
     "onion_enabled": false,
-    "test_network": true,
     "ssl_authority_paths": [],
     "send_logs_to_origintrail": false,
     "enable_debug_logs_level": false,
@@ -79,7 +77,9 @@
     "network": {
       "id": "Devnet",
       "bootstraps": ["https://46.101.38.216:5278/#d0fe3f2c8c3868f3c88f1647243d4b770eb057ea"],
-      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"]
+      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
+      "solutionDifficulty": 20,
+      "identityDifficulty": 8
     },
     "bugSnag": {
       "releaseStage": "development"
@@ -107,7 +107,6 @@
     "node_rpc_port": 8900,
     "remote_control_enabled": true,
     "node_remote_control_port": 3000,
-    "test_network_enabled": true,
     "is_bootstrap_node": false,
     "send_logs": false,
     "logs_level_debug": true,
@@ -118,7 +117,7 @@
     "ssl_certificate_path": "kademlia.crt",
     "identity_filepath": "identity.json",
     "erc725_identity_filepath": "erc725_identity.json",
-    "cpus": 1,
+    "cpus": 0,
     "embedded_wallet_directory": "wallet.dat",
     "embedded_peercache_path": "peercache",
     "onion_virtual_port": "4043",
@@ -130,7 +129,6 @@
     "control_sock_enabled": false,
     "control_sock": 12000,
     "onion_enabled": false,
-    "test_network": true,
     "ssl_authority_paths": [],
     "send_logs_to_origintrail": false,
     "enable_debug_logs_level": false,
@@ -178,7 +176,9 @@
     "network": {
       "id": "StagenetV1.0.0",
       "bootstraps": ["https://188.166.3.182:5278/#2fee0c13ad5d2e4a6a90ce9f20a07720edbd0a41"],
-      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"]
+      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
+      "solutionDifficulty": 20,
+      "identityDifficulty": 14
     },
     "bugSnag": {
       "releaseStage": "staging"
@@ -206,7 +206,6 @@
     "node_rpc_port": 8900,
     "remote_control_enabled": true,
     "node_remote_control_port": 3000,
-    "test_network_enabled": true,
     "is_bootstrap_node": false,
     "send_logs": false,
     "logs_level_debug": true,
@@ -217,7 +216,7 @@
     "ssl_certificate_path": "kademlia.crt",
     "identity_filepath": "identity.json",
     "erc725_identity_filepath": "erc725_identity.json",
-    "cpus": 1,
+    "cpus": 0,
     "embedded_wallet_directory": "wallet.dat",
     "embedded_peercache_path": "peercache",
     "onion_virtual_port": "4043",
@@ -229,7 +228,6 @@
     "control_sock_enabled": false,
     "control_sock": 12000,
     "onion_enabled": false,
-    "test_network": true,
     "ssl_authority_paths": [],
     "send_logs_to_origintrail": false,
     "enable_debug_logs_level": false,
@@ -277,7 +275,9 @@
     "network": {
       "id": "StablenetV1.0.0",
       "bootstraps": ["https://82.196.10.12:5278/#ca87147a501adf39eaa648c2b09735559ee3511d"],
-      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"]
+      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
+      "solutionDifficulty": 20,
+      "identityDifficulty": 14
     },
     "bugSnag": {
       "releaseStage": "stable"
@@ -305,7 +305,6 @@
     "node_rpc_port": 8900,
     "remote_control_enabled": true,
     "node_remote_control_port": 3000,
-    "test_network_enabled": true,
     "is_bootstrap_node": false,
     "send_logs": false,
     "logs_level_debug": true,
@@ -316,7 +315,7 @@
     "ssl_certificate_path": "kademlia.crt",
     "identity_filepath": "identity.json",
     "erc725_identity_filepath": "erc725_identity.json",
-    "cpus": 1,
+    "cpus": 0,
     "embedded_wallet_directory": "wallet.dat",
     "embedded_peercache_path": "peercache",
     "onion_virtual_port": "4043",
@@ -328,7 +327,6 @@
     "control_sock_enabled": false,
     "control_sock": 12000,
     "onion_enabled": false,
-    "test_network": true,
     "ssl_authority_paths": [],
     "send_logs_to_origintrail": false,
     "enable_debug_logs_level": false,
@@ -376,7 +374,9 @@
     "network": {
       "id": "PirotV1.0.0",
       "bootstraps": ["https://46.101.38.216:5278/#d0fe3f2c8c3868f3c88f1647243d4b770eb057ea"],
-      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"]
+      "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
+      "solutionDifficulty": 20,
+      "identityDifficulty": 14
     },
     "bugSnag": {
       "releaseStage": "pirot"

--- a/modules/network/kademlia/kademlia.js
+++ b/modules/network/kademlia/kademlia.js
@@ -34,11 +34,10 @@ class Kademlia {
         this.config = ctx.config;
 
         kadence.constants.T_RESPONSETIMEOUT = this.config.request_timeout;
-        if (this.config.test_network) {
-            this.log.warn('Node is running in test mode, difficulties are reduced');
-            kadence.constants.SOLUTION_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
-            kadence.constants.IDENTITY_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
-        }
+        kadence.constants.SOLUTION_DIFFICULTY = this.config.network.solutionDifficulty;
+        kadence.constants.IDENTITY_DIFFICULTY = this.config.network.identityDifficulty;
+        this.log.info(`Network solution difficulty ${kadence.constants.SOLUTION_DIFFICULTY}.`);
+        this.log.info(`Network identity difficulty ${kadence.constants.IDENTITY_DIFFICULTY}.`);
     }
 
     async bootstrapFindContact(contactId) {
@@ -208,6 +207,26 @@ class Kademlia {
                 )));
             this.log.info('Peercache initialised');
 
+            this.node.spartacus = this.node.plugin(kadence.spartacus(
+                this.xprivkey,
+                this.index,
+                kadence.constants.HD_KEY_DERIVATION_PATH,
+            ));
+            this.log.info('Spartacus initialised');
+
+            this.node.hashcash = this.node.plugin(kadence.hashcash({
+                methods: [
+                    'PUBLISH', 'SUBSCRIBE', 'kad-data-location-request',
+                    'kad-replication-response', 'kad-replication-finished',
+                    'kad-data-location-response', 'kad-data-read-request',
+                    'kad-data-read-response', 'kad-send-encrypted-key',
+                    'kad-encrypted-key-process-result',
+                    'kad-replication-response', 'kad-replication-finished',
+                ],
+                difficulty: this.config.network.solutionDifficulty,
+            }));
+            this.log.info('Hashcash initialised');
+
             if (this.config.onion_enabled) {
                 this.enableOnion();
             }
@@ -266,6 +285,7 @@ class Kademlia {
             new kadence.traverse.ReverseTunnelStrategy({
                 remotePort,
                 remoteAddress,
+                privateKey: this.xprivkey,
                 secureLocalConnection: true,
                 verboseLogging: false,
             }),

--- a/modules/network/kademlia/workers/identity.js
+++ b/modules/network/kademlia/workers/identity.js
@@ -1,11 +1,10 @@
 const kadence = require('@kadenceproject/kadence');
 const readLine = require('readline');
-const { EventEmitter } = require('events');
 
 process.once('message', ([xprv, index, path, options]) => {
-    if (options && options.test_network) {
-        kadence.constants.SOLUTION_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
-        kadence.constants.IDENTITY_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
+    if (options && options.solutionDifficulty && options.identityDifficulty) {
+        kadence.constants.SOLUTION_DIFFICULTY = options.solutionDifficulty;
+        kadence.constants.IDENTITY_DIFFICULTY = options.identityDifficulty;
     }
 
     const identity = new kadence.eclipse.EclipseIdentity(xprv, index, path);

--- a/modules/network/kademlia/workers/solver.js
+++ b/modules/network/kademlia/workers/solver.js
@@ -1,12 +1,10 @@
 const kadence = require('@kadenceproject/kadence');
 const readLine = require('readline');
 
-if (parseInt(process.env.kadence_TestNetworkEnabled, 10)) {
-    kadence.constants.SOLUTION_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
-    kadence.constants.IDENTITY_DIFFICULTY = kadence.constants.TESTNET_DIFFICULTY;
-}
+process.once('message', ({ privateKey, solutionDifficulty, identityDifficulty }) => {
+    kadence.constants.SOLUTION_DIFFICULTY = solutionDifficulty;
+    kadence.constants.IDENTITY_DIFFICULTY = identityDifficulty;
 
-process.once('message', ({ privateKey }) => {
     const solver = new kadence.permission.PermissionSolver(Buffer.from(privateKey, 'hex'));
 
     solver.on('data', (data) => {

--- a/scripts/identity-cli.js
+++ b/scripts/identity-cli.js
@@ -8,8 +8,10 @@ const hdkey = require('hdkey');
 const kadence = require('@kadenceproject/kadence');
 const argv = require('minimist')(process.argv.slice(2));
 
-let cpus = 1;
+let cpus = 0;
 let testNetwork = 1;
+let solutionDifficulty = 20;
+let identityDifficulty = 8;
 const solvers = [];
 
 /**
@@ -47,7 +49,11 @@ function forkIdentityDerivationSolver(c, xprv, index, derivationPath, events) {
         console.error(`Derivation ${c} error, ${err.message}`);
     });
 
-    const options = { test_network: testNetwork };
+
+    const options = {
+        solutionDifficulty,
+        identityDifficulty,
+    };
     solver.send([xprv, index, derivationPath, options]);
 
     return solver;
@@ -63,8 +69,8 @@ function forkIdentityDerivationSolver(c, xprv, index, derivationPath, events) {
 async function spawnIdentityDerivationProcesses(xprivkey, path, events) {
     // How many process can we run
     if (cpus === 0) {
-        console.info('There are no derivation processes running');
-        return;
+        cpus = os.cpus().length;
+        console.info(`Using ${cpus} cores for derivation.`);
     }
     if (os.cpus().length < cpus) {
         console.error('Refusing to start more solvers than cpu cores');
@@ -130,6 +136,13 @@ async function solveIdentity(xprivkey, path) {
 
 if (argv.cpus) {
     cpus = argv.cpus;
+}
+if (argv.identityDifficulty) {
+    identityDifficulty = argv.identityDifficulty;
+}
+
+if (argv.solutionDifficulty) {
+    solutionDifficulty = argv.solutionDifficulty;
 }
 
 async function main() {

--- a/test/bdd/features/network.feature
+++ b/test/bdd/features/network.feature
@@ -3,6 +3,7 @@ Feature: Test basic network features
     Given the blockchain is set up
     And 1 bootstrap is running
 
+  @itworks
   Scenario: Start network with 5 nodes and check do they see each other
     Given I setup 5 nodes
     And I start the nodes

--- a/test/bdd/steps/lib/otnode.js
+++ b/test/bdd/steps/lib/otnode.js
@@ -43,11 +43,12 @@ class OtNode extends EventEmitter {
 
     initialize() {
         mkdirp.sync(this.options.configDir);
-        execSync(`npm run setup -- --configDir=${this.options.configDir}`);
+        this.configFilePath = path.join(this.options.configDir, 'initial-configuration.json');
         fs.writeFileSync(
-            path.join(this.options.configDir, 'config.json'),
-            JSON.stringify(this.options.nodeConfiguration),
+            this.configFilePath,
+            JSON.stringify(this.options.nodeConfiguration, null, 4),
         );
+        execSync(`npm run setup -- --configDir=${this.options.configDir} --config ${this.configFilePath}`);
 
         if (this.options.identity) {
             fs.writeFileSync(
@@ -92,7 +93,7 @@ class OtNode extends EventEmitter {
         // Enable debug here process.env.NODE_DEBUG = 'https';
         this.process = spawn(
             'node',
-            ['ot-node.js', `--configDir=${this.options.configDir}`],
+            ['ot-node.js', `--configDir=${this.options.configDir}`, '--config', `${this.configFilePath}`],
             { cwd: path.join(__dirname, '../../../../') },
         );
         this.process.on('close', code => this._processExited(code));

--- a/test/bdd/steps/network.js
+++ b/test/bdd/steps/network.js
@@ -45,13 +45,13 @@ Given(/^(\d+) bootstrap is running$/, { timeout: 80000 }, function (nodeCount, d
                 rpc_node_port: 7545,
             },
             network: {
-                bootstraps: ['https://localhost:5278/#ba9f7526f803490e631859c75d56e5ab25a47a33'],
+                bootstraps: ['https://localhost:5278/#ff62cb1f692431d901833d55b93c7d991b4087f1'],
                 remoteWhitelist: ['localhost'],
             },
         },
     });
 
-    bootstrapNode.options.identity = bootstrapIdentity.ba9f7526f803490e631859c75d56e5ab25a47a33;
+    bootstrapNode.options.identity = bootstrapIdentity.ff62cb1f692431d901833d55b93c7d991b4087f1;
     bootstrapNode.initialize();
     this.state.bootstraps.push(bootstrapNode);
 
@@ -71,7 +71,7 @@ Given(/^I setup (\d+) node[s]*$/, { timeout: 120000 }, function (nodeCount, done
                 node_rpc_port: 9000 + i,
                 node_remote_control_port: 4000 + i,
                 network: {
-                    bootstraps: ['https://localhost:5278/#ba9f7526f803490e631859c75d56e5ab25a47a33'],
+                    bootstraps: ['https://localhost:5278/#ff62cb1f692431d901833d55b93c7d991b4087f1'],
                     remoteWhitelist: ['localhost'],
                 },
                 database: {

--- a/test/bdd/steps/network.js
+++ b/test/bdd/steps/network.js
@@ -16,10 +16,11 @@ const LocalBlockchain = require('./lib/local-blockchain');
 const httpApiHelper = require('./lib/http-api-helper');
 const ImportUtilities = require('../../../modules/ImportUtilities');
 
+// Identity difficulty 8.
 const bootstrapIdentity = {
-    ba9f7526f803490e631859c75d56e5ab25a47a33: {
-        xprivkey: 'xprv9s21ZrQH143K4MkqK5soWDhkWWzhCauPCvb1faFfvp1kaLTMV76CScnYHWZNALh3YXEPJNkAcesHidcoVSpP7efcDhnEQDQYkWxEnZtDMYR',
-        index: 0,
+    ff62cb1f692431d901833d55b93c7d991b4087f1: {
+        xprivkey: 'xprv9s21ZrQH143K3HeLBdzpC75mK2nW8HSsrLRm7RU7yS3W6hNQFibGTYiWpAKAsJm6LQPyp6khWQ5mGvFVPeMqehQj1pUCkTWMTw1G5HHJow5',
+        index: 1610612758,
     },
 };
 

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -16,10 +16,10 @@ describe('Utilities module', () => {
             const config = configJson[environment];
             assert.hasAllKeys(
                 config, ['node_rpc_ip', 'node_port', 'blockchain', 'database', 'identity', 'node_ip', 'logs_level_debug',
-                    'request_timeout', 'ssl_keypath', 'node_remote_control_port', 'send_logs', 'test_network_enabled',
+                    'request_timeout', 'ssl_keypath', 'node_remote_control_port', 'send_logs',
                     'ssl_certificate_path', 'identity_filepath', 'cpus', 'embedded_wallet_directory',
                     'embedded_peercache_path', 'onion_virtual_port', 'traverse_nat_enabled', 'traverse_port_forward_ttl', 'verbose_logging',
-                    'control_port_enabled', 'control_port', 'control_sock_enabled', 'control_sock', 'onion_enabled', 'test_network',
+                    'control_port_enabled', 'control_port', 'control_sock_enabled', 'control_sock', 'onion_enabled',
                     'ssl_authority_paths', 'node_rpc_port',
                     'remote_control_enabled', 'probability_threshold',
                     'read_stake_factor', 'dh_max_time_mins', 'dh_price', 'dh_stake_factor', 'send_logs_to_origintrail',
@@ -41,7 +41,7 @@ describe('Utilities module', () => {
                 `Some config items are missing in config.blockchain for environment '${environment}'`,
             );
             assert.hasAllKeys(
-                config.network, ['id', 'bootstraps', 'remoteWhitelist'],
+                config.network, ['id', 'bootstraps', 'remoteWhitelist', 'identityDifficulty', 'solutionDifficulty'],
                 `Some config items are missing in config.network for environment '${environment}'`,
             );
             assert.hasAllKeys(


### PR DESCRIPTION
- Enable Hashcash and Spartacus plugin.
- Set default difficulty for each environment.
- Use more cores when depriving identities.
- Fail if identity not valid.