### PR TITLE
Network identification update (part of #161808122 and #159885778)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -75,6 +75,7 @@
       ]
     },
     "network": {
+      "hostname": "127.0.0.1",
       "id": "Devnet",
       "bootstraps": ["https://46.101.38.216:5278/#d0fe3f2c8c3868f3c88f1647243d4b770eb057ea"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],

--- a/config/config.json
+++ b/config/config.json
@@ -379,8 +379,11 @@
     },
     "network": {
       "hostname": "127.0.0.1",
-      "id": "PirotV1.0.0",
-      "bootstraps": ["https://46.101.38.216:5278/#941d1226cef9e4b52531113944a0a692508614d2"],
+      "id": "TestnetV1.0.5b",
+      "bootstraps": [
+        "https://46.101.233.127:5278/#a69e413b7916a22658e1435b498761ff3d922b56",
+        "https://82.196.6.215:5278/#d3167d777720c15e024b7e7ab41055bcdf1bf03e"
+      ],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
       "solutionDifficulty": 20,
       "identityDifficulty": 12
@@ -390,7 +393,7 @@
     },
     "autoUpdater": {
       "repo": "OriginTrail/ot-node",
-      "branch": "feature/network-addressing"
+      "branch": "master"
     },
     "dataSetStorage": "data_set_storage",
     "dc_holding_time_in_minutes": 10080,

--- a/config/config.json
+++ b/config/config.json
@@ -390,7 +390,7 @@
     },
     "autoUpdater": {
       "repo": "OriginTrail/ot-node",
-      "branch": "feature/pirot"
+      "branch": "feature/network-addressing"
     },
     "dataSetStorage": "data_set_storage",
     "dc_holding_time_in_minutes": 10080,

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,6 @@
   "development": {
     "identity": null,
     "houston_password": null,
-    "node_ip": "127.0.0.1",
     "node_port": 5278,
     "node_rpc_ip": "127.0.0.1",
     "node_rpc_port": 8900,
@@ -103,7 +102,6 @@
   "staging": {
     "identity": null,
     "houston_password": null,
-    "node_ip": "127.0.0.1",
     "node_port": 5278,
     "node_rpc_ip": "127.0.0.1",
     "node_rpc_port": 8900,
@@ -204,7 +202,6 @@
   "stable": {
     "identity": null,
     "houston_password": null,
-    "node_ip": "127.0.0.1",
     "node_port": 5278,
     "node_rpc_ip": "127.0.0.1",
     "node_rpc_port": 8900,
@@ -305,7 +302,6 @@
   "production": {
     "identity": null,
     "houston_password": null,
-    "node_ip": "127.0.0.1",
     "node_port": 5278,
     "node_rpc_ip": "127.0.0.1",
     "node_rpc_port": 8900,
@@ -409,7 +405,6 @@
   "mariner": {
     "identity": null,
     "houston_password": null,
-    "node_ip": "127.0.0.1",
     "node_port": 5278,
     "node_rpc_ip": "127.0.0.1",
     "node_rpc_port": 8900,

--- a/config/config.json
+++ b/config/config.json
@@ -176,6 +176,7 @@
       ]
     },
     "network": {
+      "hostname": "127.0.0.1",
       "id": "StagenetV1.0.0",
       "bootstraps": ["https://stagingbs.origintrial.me:5278/#1754b56ce26212eab45bc523c36e1d4bf57ea30e"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
@@ -276,6 +277,7 @@
       ]
     },
     "network": {
+      "hostname": "127.0.0.1",
       "id": "StablenetV1.0.0",
       "bootstraps": ["https://82.196.10.12:5278/#ca87147a501adf39eaa648c2b09735559ee3511d"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
@@ -376,6 +378,7 @@
       ]
     },
     "network": {
+      "hostname": "127.0.0.1",
       "id": "PirotV1.0.0",
       "bootstraps": ["https://46.101.38.216:5278/#941d1226cef9e4b52531113944a0a692508614d2"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
@@ -476,6 +479,7 @@
       ]
     },
     "network": {
+      "hostname": "127.0.0.1",
       "id": "MarinerV1.0.0",
       "bootstraps": [
         "https://35.159.51.107:5278/#3e3f9f62aa3e55c4bc2e307e2164357e538466a5",

--- a/modules/Utilities.js
+++ b/modules/Utilities.js
@@ -14,7 +14,6 @@ const neo4j = require('neo4j-driver').v1;
 const levenshtein = require('js-levenshtein');
 const BN = require('bn.js');
 const numberToBN = require('number-to-bn');
-const externalip = require('externalip');
 const sortedStringify = require('sorted-json-stringify');
 const mkdirp = require('mkdirp');
 const path = require('path');
@@ -766,21 +765,6 @@ class Utilities {
             [a[i], a[j]] = [a[j], a[i]];
         }
         return a;
-    }
-
-    /**
-     * Get external IP
-     * @returns {Promise}
-     */
-    static getExternalIp() {
-        return new Promise((resolve, reject) => {
-            externalip((err, ip) => {
-                if (err) {
-                    reject(err);
-                }
-                resolve(ip);
-            });
-        });
     }
 
     /**

--- a/modules/network/kademlia/kademlia-utils.js
+++ b/modules/network/kademlia/kademlia-utils.js
@@ -37,6 +37,31 @@ class KademliaUtils {
     }
 
     /**
+     * Returns certificates based on configuration.
+     *
+     * If config.node_rpc_use_ssl enabled a certificate for RPC will be used
+     * (node_rpc_ssl_key_path, node_rpc_ssl_cert_path).
+     */
+    getCertificates() {
+        if (this.config.node_rpc_use_ssl) {
+            return {
+                key: fs.readFileSync(this.config.node_rpc_ssl_key_path),
+                cert: fs.readFileSync(this.config.node_rpc_ssl_cert_path),
+            };
+        }
+        return {
+            key: fs.readFileSync(path.join(
+                this.config.appDataPath,
+                this.config.ssl_keypath,
+            )),
+            cert: fs.readFileSync(path.join(
+                this.config.appDataPath,
+                this.config.ssl_certificate_path,
+            )),
+        };
+    }
+
+    /**
     * Mining a new identity
     * @return {Promise<void>}
     */

--- a/modules/network/kademlia/kademlia.js
+++ b/modules/network/kademlia/kademlia.js
@@ -113,7 +113,8 @@ class Kademlia {
             const { hostname } = this.config.network;
             if (!this.config.local_network_only && !this.config.traverse_nat_enabled) {
                 if (ip.isPrivate(hostname) || hostname === 'localhost') {
-                    throw Error('Please set node\'s hostname (address) to externally available');
+                    throw Error('Please set node\'s hostname (address) ' +
+                        'to something publicly visible.');
                 }
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2637,11 +2637,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
-      "integrity": "sha1-PRJ1L2rfaKiS8zJDNJK9WBK7Zo8="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -4629,116 +4624,6 @@
         "tmp": "0.0.33"
       }
     },
-    "externalip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/externalip/-/externalip-1.0.2.tgz",
-      "integrity": "sha1-Kjfb/ch7PZnCSrfi3NYVAJZ43fc=",
-      "requires": {
-        "superagent": "0.18.2"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "combined-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-          "requires": {
-            "delayed-stream": "0.0.5"
-          }
-        },
-        "component-emitter": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
-        },
-        "debug": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.5.tgz",
-          "integrity": "sha1-9yQSF0MPmd7EwrRz6rkiKOh0wqw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "delayed-stream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
-        },
-        "extend": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
-          "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w="
-        },
-        "form-data": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
-          "integrity": "sha1-TuQ0bm61Ni6DRKAgdb2NvYxzc+o=",
-          "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime": "1.2.11"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "mime": {
-          "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "qs": {
-          "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-          "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
-        },
-        "readable-stream": {
-          "version": "1.0.27-1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        },
-        "superagent": {
-          "version": "0.18.2",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.18.2.tgz",
-          "integrity": "sha1-mvxidqlHX0vc1TWsagaF68S1YOs=",
-          "requires": {
-            "component-emitter": "1.1.2",
-            "cookiejar": "2.0.1",
-            "debug": "1.0.5",
-            "extend": "1.2.1",
-            "form-data": "0.1.3",
-            "formidable": "1.0.14",
-            "methods": "1.0.1",
-            "mime": "1.2.11",
-            "qs": "0.6.6",
-            "readable-stream": "1.0.27-1",
-            "reduce-component": "1.0.1"
-          }
-        }
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -5077,11 +4962,6 @@
         "combined-stream": "1.0.6",
         "mime-types": "2.1.18"
       }
-    },
-    "formidable": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
-      "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -12427,11 +12307,6 @@
       "resolved": "https://registry.npmjs.org/metapipe/-/metapipe-2.0.2.tgz",
       "integrity": "sha512-BLQ+3J2OTMXWFLyoav/sl1sPIpDt3EaJSDpov1gitKoYl8uWfkXPOUplYJip/DWIaKd45LdsOuOR0k1jjDaacg=="
     },
-    "methods": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
-      "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us="
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -12574,7 +12449,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -19436,11 +19311,6 @@
       "requires": {
         "resolve": "1.8.1"
       }
-    },
-    "reduce-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
     },
     "regenerate": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^5.2.0",
     "ethereumjs-wallet": "^0.6.2",
-    "externalip": "^1.0.2",
     "github-release-notes": "^0.16.0",
     "hdkey": "^0.8.0",
     "ip": "^1.1.5",

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -15,7 +15,7 @@ describe('Utilities module', () => {
         environments.forEach((environment) => {
             const config = configJson[environment];
             assert.hasAllKeys(
-                config, ['node_rpc_ip', 'node_port', 'blockchain', 'database', 'identity', 'node_ip', 'logs_level_debug',
+                config, ['node_rpc_ip', 'node_port', 'blockchain', 'database', 'identity', 'logs_level_debug',
                     'request_timeout', 'ssl_keypath', 'node_remote_control_port', 'send_logs',
                     'ssl_certificate_path', 'identity_filepath', 'cpus', 'embedded_wallet_directory',
                     'embedded_peercache_path', 'onion_virtual_port', 'traverse_nat_enabled', 'traverse_port_forward_ttl', 'verbose_logging',
@@ -41,7 +41,11 @@ describe('Utilities module', () => {
                 `Some config items are missing in config.blockchain for environment '${environment}'`,
             );
             assert.hasAllKeys(
-                config.network, ['id', 'bootstraps', 'remoteWhitelist', 'identityDifficulty', 'solutionDifficulty'],
+                config.network, [
+                    'id', 'hostname', 'bootstraps',
+                    'remoteWhitelist', 'identityDifficulty',
+                    'solutionDifficulty',
+                ],
                 `Some config items are missing in config.network for environment '${environment}'`,
             );
             assert.hasAllKeys(

--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -72,13 +72,6 @@ function main() {
         externalConfig.remoteWhitelist = process.env.IMPORT_WHITELIST.split(',');
     }
 
-    if (process.env.INSTALLATION === 'local') {
-        externalConfig.node_ip = '127.0.0.1'; // TODO remove
-    } else {
-        // TODO: Use system command for this.
-        externalConfig.node_ip = ip.address();
-    }
-
     deepExtend(localConfiguration, externalConfig);
     console.log('Configuration:');
     // Mask private key before printing it.


### PR DESCRIPTION
Update network identification to allow using domain names in contact's identification. Also, this change will allow setting any non-local ip address or domain name. It's not assumed that listening address is localhost (127.0.0.1) and forces user to set what is going to be a node's network address.
After this change node won't allow to identifies with 127.0.0.1 address.
Other things:
- It's now allowed to use same SSL keys for node and RPC server.
- Removed dependency to external-ip package.