### PR TITLE
Disable Hashcash for PUBLISH/SUBSCRIBE. Collect responses after publish.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -175,7 +175,7 @@
     },
     "network": {
       "hostname": "127.0.0.1",
-      "id": "StagenetV1.0.0",
+      "id": "StagenetV1.0.1",
       "bootstraps": ["https://stagingbs.origintrial.me:5278/#1754b56ce26212eab45bc523c36e1d4bf57ea30e"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
       "solutionDifficulty": 14,
@@ -275,7 +275,7 @@
     },
     "network": {
       "hostname": "127.0.0.1",
-      "id": "StablenetV1.0.0",
+      "id": "StablenetV1.0.1",
       "bootstraps": ["https://82.196.10.12:5278/#e2f7ab11d0dd34595dfb2e71b4937ec8d790df84"],
       "remoteWhitelist": ["54.93.223.161", "127.0.0.1"],
       "solutionDifficulty": 14,
@@ -375,7 +375,7 @@
     },
     "network": {
       "hostname": "127.0.0.1",
-      "id": "TestnetV2.0.0b",
+      "id": "TestnetV2.0.1b",
       "bootstraps": [
         "https://46.101.233.127:5278/#41d7357b322ca75d1187b3163b510ff704e9a040",
         "https://82.196.6.215:5278/#9e7f1ec47d0da65b9f2e004510ae366519290dff"
@@ -478,7 +478,7 @@
     },
     "network": {
       "hostname": "127.0.0.1",
-      "id": "MarinerV1.0.0",
+      "id": "MarinerV1.0.1",
       "bootstraps": [
         "https://35.159.51.107:5278/#3e3f9f62aa3e55c4bc2e307e2164357e538466a5",
         "https://142.93.13.94:5278/#6d3e620c2c4062e67ed16f86c2fd9c6fec739644"

--- a/modules/EventEmitter.js
+++ b/modules/EventEmitter.js
@@ -326,7 +326,6 @@ class EventEmitter {
                         message: 'Query sent successfully.',
                         query_id: queryId,
                     });
-                    dvController.handleQuery(queryId, 60000);
                 }).catch((error) => {
                     logger.error(`Failed query network. ${error}.`);
                     notifyError(error);

--- a/modules/command/dv/dv-query-network-command.js
+++ b/modules/command/dv/dv-query-network-command.js
@@ -71,7 +71,18 @@ class DVQueryNetworkCommand extends Command {
 
         await this.transport.publish('kad-data-location-request', dataLocationRequestObject);
         this.logger.info(`Published query to the network. Query ID ${queryId}.`);
-        return Command.empty();
+        return {
+            commands: [
+                {
+                    name: 'dvHandleNetworkQueryResponsesCommand',
+                    delay: 60000,
+                    data: {
+                        queryId,
+                    },
+                    transactional: false,
+                },
+            ],
+        };
     }
 
     /**

--- a/modules/network/kademlia/kademlia.js
+++ b/modules/network/kademlia/kademlia.js
@@ -234,7 +234,7 @@ class Kademlia {
 
             this.node.hashcash = this.node.plugin(kadence.hashcash({
                 methods: [
-                    'PUBLISH', 'SUBSCRIBE', 'kad-data-location-request',
+                    'kad-data-location-request',
                     'kad-replication-finished', 'kad-data-location-response', 'kad-data-read-request',
                     'kad-data-read-response', 'kad-send-encrypted-key',
                     'kad-encrypted-key-process-result',


### PR DESCRIPTION
Changes:
- Disable Hashcash for PUBLIC and SUBSCRIBE methods since they potentially stall node since mining is happening in main thread. Postpone using Hashcash for mentioned methods until Kadence update.
- Start measuring 1 minute for data location queries upon successful publish.
- New network environment ID due to the changes in the API.