### PR TITLE
Fix for litigation when DH only answer to BC event

### DIFF
--- a/modules/command/dc/dc-litigation-completed-command.js
+++ b/modules/command/dc/dc-litigation-completed-command.js
@@ -90,6 +90,14 @@ class DCLitigationCompleted extends Command {
                     };
                 }
 
+                const offer = await models.offers.findOne({
+                    where: {
+                        offer_id: offerId,
+                    },
+                });
+
+                offer.global_status = 'ACTIVE';
+                await offer.save({ fields: ['global_status'] });
                 this.logger.important(`DH ${dhIdentity} has successfully answered litigation.`);
                 return Command.empty();
             }

--- a/test/bdd/features/litigation.feature
+++ b/test/bdd/features/litigation.feature
@@ -100,3 +100,20 @@ Feature: Test various litigation scenarios
     And I wait for litigation initiation
     Then I wait for 3 replacement replications to finish
     Then I wait for replacement to be completed
+
+  Scenario: Test litigation case
+    Given the replication difficulty is 0
+    And I setup 4 nodes
+    When I override configuration for all nodes
+      | dc_holding_time_in_minutes | 5 |
+      | numberOfChallenges | 1 |
+    And I start the nodes
+    And I use 1st node as DC
+    And DC imports "importers/xml_examples/Retail/01_Green_to_pink_shipment.xml" as GS1
+    Given DC initiates the replication for last imported dataset
+    And I wait for 4th node to verify replication
+    And I stop the 4th node
+    And I wait for replications to finish
+    When I wait for litigation initiation
+    And I simulate true litigation answer for 4th node
+    Then the last offer's status for 4th node should be active

--- a/test/bdd/steps/lib/local-blockchain.js
+++ b/test/bdd/steps/lib/local-blockchain.js
@@ -129,6 +129,7 @@ class LocalBlockchain {
                 assert(this.profileContractAddress !== '0x0000000000000000000000000000000000000000');
                 assert(this.holdingContractAddress !== '0x0000000000000000000000000000000000000000');
                 assert(this.readingContractAddress !== '0x0000000000000000000000000000000000000000');
+                assert(this.litigationContractAddress !== '0x0000000000000000000000000000000000000000');
                 accept();
             });
         });
@@ -391,6 +392,10 @@ class LocalBlockchain {
 
     get readingContractAddress() {
         return this.readingInstance._address;
+    }
+
+    get litigationContractAddress() {
+        return this.litigationInstance._address;
     }
 
     get isInitialized() {

--- a/test/bdd/steps/lib/otnode.js
+++ b/test/bdd/steps/lib/otnode.js
@@ -304,6 +304,8 @@ class OtNode extends EventEmitter {
         } else if (line.match(/Litigation initiated for DH .+ and offer .+\./gi)) {
             this.state.litigationStatus = 'LITIGATION_STARTED';
             this.emit('dc-litigation-initiated');
+        } else if (line.match(/Litigation answered for DH .+ and offer .+\./gi)) {
+            this.emit('dc-litigation-answered');
         } else if (line.match(/Litigation answered for offer .+\. DH identity .+/gi)) {
             this.emit('dh-litigation-answered');
         } else if (line.match(/Litigation completed for DH .+ and offer .+\./gi)) {
@@ -337,6 +339,9 @@ class OtNode extends EventEmitter {
             const offerId = line.match(offerIdRegex)[0];
             this.state.takenBids.push(offerId);
             this.emit('dh-chosen-as-replacement');
+        } else if (line.match(/Replication finished for DH node .+/gi)) {
+            const nodeId = line.match(identityRegex)[0];
+            this.emit('dh-replication-verified', nodeId);
         }
     }
 
@@ -346,6 +351,21 @@ class OtNode extends EventEmitter {
      */
     get isRunning() {
         return this.initialized && this.started && !!this.process;
+    }
+
+    /**
+     * Retruns path to the system.db.
+     * @return {string} Path.
+     */
+    get systemDbPath() {
+        return path.join(this.options.configDir, 'system.db');
+    }
+
+    get erc725Identity() {
+        return JSON.parse(fs.readFileSync(path.join(
+            this.options.configDir,
+            'erc725_identity.json',
+        ))).identity;
     }
 
     /**


### PR DESCRIPTION
Fix potential problem when node replication status is left stuck in litigation when DH only replies to blockchain events.

Add testcase to fix this situation.