### PR TITLE
Use own RPC host

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -56,8 +56,6 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "hub_contract_address": "0x056f4DA796C00766061158A01cE068D912be9c89",
-      "rpc_node_host": "https://rinkeby.infura.io/1WRiEqAQ9l4SW6fGdiDt",
-      "rpc_node_port": "",
       "plugins": [
         {
           "enabled": false,
@@ -155,9 +153,7 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
-      "hub_contract_address": "0x0A0253150F35D9a766e450D6F749fFFD2B21eEC6",
-      "rpc_node_host": "https://rinkeby.infura.io/1WRiEqAQ9l4SW6fGdiDt",
-      "rpc_node_port": "",
+      "hub_contract_address": "0x16d553B9765b6Aa9fE7C45Dfa1a1839fD88DD7bc",
       "plugins": [
         {
           "enabled": false,
@@ -256,8 +252,6 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "hub_contract_address": "0x6C314872A7e97A6F1dC7De2dc43D28500dd36f22",
-      "rpc_node_host": "https://rinkeby.infura.io/1WRiEqAQ9l4SW6fGdiDt",
-      "rpc_node_port": "",
       "plugins": [
         {
           "enabled": false,
@@ -355,9 +349,7 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
-      "hub_contract_address": "0xE2726Bc7c82d45601eF68DB9EED92af18D0C4E0f",
-      "rpc_node_host": "https://rinkeby.infura.io/1WRiEqAQ9l4SW6fGdiDt",
-      "rpc_node_port": "",
+      "hub_contract_address": "0x0e5995FE34BfC9DB7a31fa318f7f1256Cf28FfCa",
       "plugins": [
         {
           "enabled": false,
@@ -459,8 +451,6 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "hub_contract_address": "0xa287d7134fb40bef071c932286bd2cd01efccf30",
-      "rpc_node_host": "https://mainnet.infura.io/7c072f60df864d22884e705c5bf3d83f",
-      "rpc_node_port": "",
       "plugins": [
         {
           "enabled": false,

--- a/ot-node.js
+++ b/ot-node.js
@@ -84,6 +84,11 @@ try {
         console.error('Please provide a valid management wallet.');
         process.abort();
     }
+
+    if (!config.blockchain.rpc_server_url) {
+        console.error('Please provide a valid RPC server URL.');
+        process.abort();
+    }
 } catch (error) {
     console.error(`Failed to read configuration. ${error}.`);
     console.error(error.stack);
@@ -295,7 +300,7 @@ class OTNode {
         }
 
         const web3 =
-            new Web3(new Web3.providers.HttpProvider(`${config.blockchain.rpc_node_host}:${config.blockchain.rpc_node_port}`));
+            new Web3(new Web3.providers.HttpProvider(config.blockchain.rpc_server_url));
 
         const appState = {};
         if (config.is_bootstrap_node) {

--- a/test/bdd/steps/network.js
+++ b/test/bdd/steps/network.js
@@ -76,8 +76,7 @@ Given(/^(\d+) bootstrap is running$/, { timeout: 80000 }, function (nodeCount, d
             },
             blockchain: {
                 hub_contract_address: this.state.localBlockchain.hubContractAddress,
-                rpc_node_host: 'http://localhost', // TODO use from instance
-                rpc_node_port: 7545,
+                rpc_server_url: 'http://localhost:7545/', // TODO use from instance
             },
             network: {
                 // TODO: Connect other if using multiple.
@@ -119,8 +118,7 @@ Given(/^I setup (\d+) node[s]*$/, { timeout: 120000 }, function (nodeCount, done
             },
             blockchain: {
                 hub_contract_address: this.state.localBlockchain.hubContractAddress,
-                rpc_node_host: 'http://localhost', // TODO use from instance
-                rpc_node_port: 7545,
+                rpc_server_url: 'http://localhost:7545/', // TODO use from instance
             },
             local_network_only: true,
             dc_choose_time: 60000, // 1 minute
@@ -535,8 +533,7 @@ Given(/^I additionally setup (\d+) node[s]*$/, { timeout: 60000 }, function (nod
                 },
                 blockchain: {
                     hub_contract_address: this.state.localBlockchain.hubContractAddress,
-                    rpc_node_host: 'http://localhost', // TODO use from instance
-                    rpc_node_port: 7545,
+                    rpc_server_url: 'http://localhost:7545/', // TODO use from instance
                 },
                 local_network_only: true,
                 initial_deposit_amount: '10000000000000000000000',

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -37,7 +37,7 @@ describe('Utilities module', () => {
             assert.hasAllKeys(
                 config.blockchain, [
                     'blockchain_title', 'network_id', 'gas_limit', 'gas_price',
-                    'hub_contract_address', 'rpc_node_host', 'rpc_node_port', 'plugins'],
+                    'hub_contract_address', 'plugins'],
                 `Some config items are missing in config.blockchain for environment '${environment}'`,
             );
             assert.hasAllKeys(
@@ -90,7 +90,7 @@ describe('Utilities module', () => {
         environments.forEach((environment) => {
             const config = configJson[environment];
             assert.hasAllKeys(config.blockchain, ['blockchain_title', 'network_id', 'gas_limit', 'plugins',
-                'gas_price', 'hub_contract_address', 'rpc_node_host', 'rpc_node_port']);
+                'gas_price', 'hub_contract_address']);
             assert.equal(config.blockchain.blockchain_title, 'Ethereum');
         });
     });

--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -13,7 +13,7 @@ const argv = require('minimist')(process.argv.slice(2));
 
 const defaultConfig = configjson[process.env.NODE_ENV];
 const localConfiguration = rc(pjson.name, defaultConfig);
-const web3 = new Web3(new Web3.providers.HttpProvider(`${localConfiguration.blockchain.rpc_node_host}`));
+const web3 = new Web3();
 
 if (argv.configDir) {
     localConfiguration.appDataPath = argv.configDir;
@@ -34,6 +34,18 @@ function main() {
     if (fs.existsSync(localConfigPath)) {
         externalConfig = JSON.parse(fs.readFileSync(localConfigPath, 'utf8'));
     }
+
+    if (!externalConfig.blockchain || !externalConfig.blockchain.rpc_server_url) {
+        console.error('Please provide a valid RPC server URL.\n' +
+            'Add it to the blockchain section. For example:\n' +
+            '   "blockchain": {\n' +
+            '       "rpc_server_url": "http://your.server.url/"\n' +
+            '   }');
+        process.exit(1);
+        return;
+    }
+
+    web3.setProvider(new Web3.providers.HttpProvider(externalConfig.blockchain.rpc_server_url));
 
     // Check for old env variables for the sake of compatibility.
     if (process.env.NODE_WALLET) {


### PR DESCRIPTION
Do not use global Infura URL as RPC host for all nodes (#163390065) (#875)

- Introduce RPC server URL instead old rpc_node_host.
- User must provide own RPC host URL.

