### PR TITLE
Fixed event listener & certs dir leaved (OT-I1494, OT-I1495, OT-I1498)

### DIFF
--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -132,7 +132,7 @@ function upgradeContainer() {
     execSync(`mkdir -p ${initPath}`);
 
     execSync(
-        'find . ! -path . -a -not \\( -name ".origintrail_noderc" -o -name "init" -o -name "data" \\) -maxdepth 1 -exec mv {} init/ \\;',
+        'find . ! -path . -a -not \\( -name ".origintrail_noderc" -o -name "init" -o -name "data" -o -name "certs" \\) -maxdepth 1 -exec mv {} init/ \\;',
         { cwd: basePath },
     );
     execSync(`rm -rf ${path.join(initPath, 'node_modules')}`);

--- a/testnet/supervisor-event-listener.py
+++ b/testnet/supervisor-event-listener.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 def write_stdout(s):
     # only eventlistener protocol messages may be sent to stdout


### PR DESCRIPTION
* Add missing import in supervisor-event-listener.py.
* Omit 'certs' dir in /ot-node/ during container upgrade. 