### PR TITLE
Mariner release v2.0.53 

### DIFF
--- a/modules/command/common/autoupdater-command.js
+++ b/modules/command/common/autoupdater-command.js
@@ -126,7 +126,7 @@ class AutoupdaterCommand extends Command {
             name: 'autoupdaterCommand',
             data: {
             },
-            period: 2 * 60 * 1000,
+            period: 6 * 60 * 60 * 1000,
             transactional: false,
         };
         Object.assign(command, map);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "2.0.52",
+  "version": "2.0.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "2.0.52",
+  "version": "2.0.53",
   "description": "OriginTrail node",
   "main": ".eslintrc.js",
   "config": {

--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -191,6 +191,13 @@ function main() {
         externalConfig = JSON.parse(fs.readFileSync(localConfigPath, 'utf8'));
     }
 
+    if (process.env.RPC_SERVER_URL) {
+        if (externalConfig.blockchain === undefined) {
+            externalConfig.blockchain = {};
+        }
+        externalConfig.blockchain.rpc_server_url = process.env.RPC_SERVER_URL;
+    }
+
     if (!externalConfig.blockchain || !externalConfig.blockchain.rpc_server_url) {
         logger.error('Please provide a valid RPC server URL.\n' +
             'Add it to the blockchain section. For example:\n' +

--- a/testnet/register-node.js
+++ b/testnet/register-node.js
@@ -132,7 +132,7 @@ function upgradeContainer() {
     execSync(`mkdir -p ${initPath}`);
 
     execSync(
-        'find . ! -path . -a -not \\( -name ".origintrail_noderc" -o -name "init" -o -name "data" \\) -maxdepth 1 -exec mv {} init/ \\;',
+        'find . ! -path . -a -not \\( -name ".origintrail_noderc" -o -name "init" -o -name "data" -o -name "certs" \\) -maxdepth 1 -exec mv {} init/ \\;',
         { cwd: basePath },
     );
     execSync(`rm -rf ${path.join(initPath, 'node_modules')}`);

--- a/testnet/supervisor-event-listener.py
+++ b/testnet/supervisor-event-listener.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 def write_stdout(s):
     # only eventlistener protocol messages may be sent to stdout


### PR DESCRIPTION
Fixes #
- Increase update check period.
- Fix listener scrip.
- Fix upgrading the container when certs are in /ot-node/ dir.
- Support setting RPC URL using command line param.