### PR TITLE
Gas price patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
   - NODE_ENV=development ARTIFACTS_DIR=$TRAVIS_BUILD_DIR/artifacts CUCUMBER_ARTIFACTS_DIR=$ARTIFACTS_DIR/cucumber BDD_SECTION=fourth
 
 
+cache:
+  npm: false
 sudo: enabled
 services:
   - docker
@@ -34,7 +36,10 @@ script:
       npm run test:bdd -- --tags=@second --world-parameters '{"appDataBaseDir":"$CUCUMBER_ARTIFACTS_DIR","keepFailedArtifacts":true}';
     fi
   - if [[ ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$BDD_SECTION" == "third" ) || ( "$TRAVIS_EVENT_TYPE" == "cron" && "$BDD_SECTION" == "third" ) ]]; then
-    npm run test:bdd -- --tags=@third --world-parameters '{"appDataBaseDir":"$CUCUMBER_ARTIFACTS_DIR","keepFailedArtifacts":true}';
+      npm run test:bdd -- --tags=@third --world-parameters '{"appDataBaseDir":"$CUCUMBER_ARTIFACTS_DIR","keepFailedArtifacts":true}';
+    fi
+  - if [[ ("$TRAVIS_EVENT_TYPE" == "pull_request" && "$BDD_SECTION" == "fourth" ) || ( "$TRAVIS_EVENT_TYPE" == "cron" && "$BDD_SECTION" == "fourth" ) ]]; then
+      npm run test:bdd -- --tags=@fourth --world-parameters '{"appDataBaseDir":"$CUCUMBER_ARTIFACTS_DIR","keepFailedArtifacts":true}';
     fi
   - if [[ ( "$TRAVIS_EVENT_TYPE" == "pull_request" && "$BDD_SECTION" == "second" ) || ( "$TRAVIS_EVENT_TYPE" == "push" && "$BDD_SECTION" == "first" ) || ( "$TRAVIS_EVENT_TYPE" == "cron" && "$BDD_SECTION" == "first" ) ]]; then
       npm test 2> $ARTIFACTS_DIR/mocha-logs.log;

--- a/config/config.json
+++ b/config/config.json
@@ -55,7 +55,8 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
-      "hub_contract_address": "0x2B7ca432a13e0D035BC46F0d6bf3cde1E72A10E5",
+      "max_allowed_gas_price" : "50000000000",
+      "hub_contract_address": "0x056f4DA796C00766061158A01cE068D912be9c89",
       "plugins": [
         {
           "enabled": false,
@@ -96,14 +97,14 @@
     "dc_holding_time_in_minutes": 60,
     "dc_token_amount_per_holder": "50000000000000000000",
     "dc_litigation_interval_in_minutes": 5,
-    "dh_max_holding_time_in_minutes": 10080,
+    "dh_max_holding_time_in_minutes": 2635200,
     "dh_min_token_price": "10000000000000000000",
     "dh_min_litigation_interval_in_minutes": 5,
     "deposit_on_demand": true,
     "dc_choose_time": 600000,
     "requireApproval": false,
     "litigationEnabled": true,
-    "commandExecutorVerboseLoggingEnabled": false
+    "commandExecutorVerboseLoggingEnabled": true
   },
   "staging": {
     "identity": null,
@@ -161,7 +162,8 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
-      "hub_contract_address": "0xA272797Bfc59946388D89CdB6821dEeC927E0E36",
+      "max_allowed_gas_price" : "50000000000",
+      "hub_contract_address": "0x16d553B9765b6Aa9fE7C45Dfa1a1839fD88DD7bc",
       "plugins": [
         {
           "enabled": false,
@@ -202,14 +204,14 @@
     "dc_holding_time_in_minutes": 60,
     "dc_token_amount_per_holder": "1",
     "dc_litigation_interval_in_minutes": 5,
-    "dh_max_holding_time_in_minutes": 1440,
+    "dh_max_holding_time_in_minutes": 2635200,
     "dh_min_token_price": "1",
     "dh_min_litigation_interval_in_minutes": 5,
     "deposit_on_demand": false,
     "dc_choose_time": 600000,
     "requireApproval": false,
     "litigationEnabled": true,
-    "commandExecutorVerboseLoggingEnabled": false
+    "commandExecutorVerboseLoggingEnabled": true
   },
   "stable": {
     "identity": null,
@@ -267,6 +269,7 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
+      "max_allowed_gas_price" : "50000000000",
       "hub_contract_address": "0x6C314872A7e97A6F1dC7De2dc43D28500dd36f22",
       "plugins": [
         {
@@ -308,14 +311,14 @@
     "dc_holding_time_in_minutes": 60,
     "dc_token_amount_per_holder": "50000000000000000000",
     "dc_litigation_interval_in_minutes": 5,
-    "dh_max_holding_time_in_minutes": 10080,
+    "dh_max_holding_time_in_minutes": 2635200,
     "dh_min_token_price": "10000000000000000000",
     "dh_min_litigation_interval_in_minutes": 5,
     "deposit_on_demand": false,
     "dc_choose_time": 600000,
     "requireApproval": false,
     "litigationEnabled": true,
-    "commandExecutorVerboseLoggingEnabled": false
+    "commandExecutorVerboseLoggingEnabled": true
   },
   "production": {
     "identity": null,
@@ -373,7 +376,8 @@
       "network_id": "rinkeby",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
-      "hub_contract_address": "0x53F5b26EB263B96ffA83468F78DA738a3961644A",
+      "max_allowed_gas_price" : "50000000000",
+      "hub_contract_address": "0x0e5995FE34BfC9DB7a31fa318f7f1256Cf28FfCa",
       "plugins": [
         {
           "enabled": false,
@@ -417,14 +421,14 @@
     "dc_holding_time_in_minutes": 60,
     "dc_token_amount_per_holder": "50000000000000000000",
     "dc_litigation_interval_in_minutes": 5,
-    "dh_max_holding_time_in_minutes": 10080,
+    "dh_max_holding_time_in_minutes": 2635200,
     "dh_min_token_price": "10000000000000000000",
     "dh_min_litigation_interval_in_minutes": 5,
     "deposit_on_demand": false,
     "dc_choose_time": 600000,
     "requireApproval": false,
     "litigationEnabled": true,
-    "commandExecutorVerboseLoggingEnabled": false
+    "commandExecutorVerboseLoggingEnabled": true
   },
   "mariner": {
     "identity": null,
@@ -482,6 +486,7 @@
       "network_id": "mainnet",
       "gas_limit": "2000000",
       "gas_price": "20000000000",
+      "max_allowed_gas_price" : "50000000000",
       "hub_contract_address": "0xa287d7134fb40bef071c932286bd2cd01efccf30",
       "plugins": [
         {
@@ -526,13 +531,13 @@
     "dc_holding_time_in_minutes": 10080,
     "dc_token_amount_per_holder": "50000000000000000000",
     "dc_litigation_interval_in_minutes": 5,
-    "dh_max_holding_time_in_minutes": 10080,
+    "dh_max_holding_time_in_minutes": 2635200,
     "dh_min_token_price": "20000000000000000000",
     "dh_min_litigation_interval_in_minutes": 5,
     "deposit_on_demand": false,
     "dc_choose_time": 600000,
     "requireApproval": true,
     "litigationEnabled": false,
-    "commandExecutorVerboseLoggingEnabled": false
+    "commandExecutorVerboseLoggingEnabled": true
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -56,7 +56,7 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "max_allowed_gas_price" : "50000000000",
-      "hub_contract_address": "0x056f4DA796C00766061158A01cE068D912be9c89",
+      "hub_contract_address": "0x2B7ca432a13e0D035BC46F0d6bf3cde1E72A10E5",
       "plugins": [
         {
           "enabled": false,
@@ -163,7 +163,7 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "max_allowed_gas_price" : "50000000000",
-      "hub_contract_address": "0x16d553B9765b6Aa9fE7C45Dfa1a1839fD88DD7bc",
+      "hub_contract_address": "0xA272797Bfc59946388D89CdB6821dEeC927E0E36",
       "plugins": [
         {
           "enabled": false,
@@ -377,7 +377,7 @@
       "gas_limit": "2000000",
       "gas_price": "20000000000",
       "max_allowed_gas_price" : "50000000000",
-      "hub_contract_address": "0x0e5995FE34BfC9DB7a31fa318f7f1256Cf28FfCa",
+      "hub_contract_address": "0x53F5b26EB263B96ffA83468F78DA738a3961644A",
       "plugins": [
         {
           "enabled": false,
@@ -428,7 +428,7 @@
     "dc_choose_time": 600000,
     "requireApproval": false,
     "litigationEnabled": true,
-    "commandExecutorVerboseLoggingEnabled": true
+    "commandExecutorVerboseLoggingEnabled": false
   },
   "mariner": {
     "identity": null,
@@ -538,6 +538,6 @@
     "dc_choose_time": 600000,
     "requireApproval": true,
     "litigationEnabled": false,
-    "commandExecutorVerboseLoggingEnabled": true
+    "commandExecutorVerboseLoggingEnabled": false
   }
 }

--- a/migrations/201909241420156-offer-add-urgent.js
+++ b/migrations/201909241420156-offer-add-urgent.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+    up: async (queryInterface, Sequelize) =>
+        queryInterface.addColumn(
+            'offers',
+            'urgent',
+            {
+                type: Sequelize.BOOLEAN,
+            },
+        ),
+    down: queryInterface => queryInterface.removeColumn('offers', 'urgent'),
+};

--- a/models/offers.js
+++ b/models/offers.js
@@ -16,6 +16,7 @@ module.exports = (sequelize, DataTypes) => {
         blue_litigation_hash: DataTypes.STRING,
         green_litigation_hash: DataTypes.STRING,
         task: DataTypes.STRING,
+        urgent: DataTypes.BOOLEAN,
         status: DataTypes.STRING,
         global_status: DataTypes.STRING,
         message: DataTypes.STRING,

--- a/modules/Blockchain.js
+++ b/modules/Blockchain.js
@@ -178,8 +178,8 @@ class Blockchain {
      * @param offerId
      * @returns {Promise}
      */
-    payOut(blockchainIdentity, offerId) {
-        return this.blockchain.payOut(blockchainIdentity, offerId);
+    payOut(blockchainIdentity, offerId, urgent) {
+        return this.blockchain.payOut(blockchainIdentity, offerId, urgent);
     }
 
     /**
@@ -198,6 +198,7 @@ class Blockchain {
         tokenAmountPerHolder,
         dataSizeInBytes,
         litigationIntervalInMinutes,
+        urgent,
     ) {
         return this.blockchain.createOffer(
             blockchainIdentity,
@@ -211,6 +212,7 @@ class Blockchain {
             tokenAmountPerHolder,
             dataSizeInBytes,
             litigationIntervalInMinutes,
+            urgent,
         );
     }
 
@@ -227,11 +229,11 @@ class Blockchain {
         confirmation3,
         encryptionType,
         holders,
-        parentIdentity,
+        urgent,
     ) {
         return this.blockchain.finalizeOffer(
             blockchainIdentity, offerId, shift, confirmation1,
-            confirmation2, confirmation3, encryptionType, holders, parentIdentity,
+            confirmation2, confirmation3, encryptionType, holders, urgent,
         );
     }
 

--- a/modules/Blockchain.js
+++ b/modules/Blockchain.js
@@ -229,11 +229,12 @@ class Blockchain {
         confirmation3,
         encryptionType,
         holders,
+        parentIdentity,
         urgent,
     ) {
         return this.blockchain.finalizeOffer(
             blockchainIdentity, offerId, shift, confirmation1,
-            confirmation2, confirmation3, encryptionType, holders, urgent,
+            confirmation2, confirmation3, encryptionType, holders, parentIdentity, urgent,
         );
     }
 

--- a/modules/Blockchain/Ethereum/index.js
+++ b/modules/Blockchain/Ethereum/index.js
@@ -664,12 +664,26 @@ class Ethereum {
     }
 
     /**
+     * Gets the current block if one wasn't retrieved in the last 10 seconds
+     * @returns {int}
+     */
+    async getCurrentBlock() {
+        const timeout = 10000;
+        if (this.lastBlockCheck == null || this.lastBlockCheck + timeout < Date.now()) {
+            this.lastBlock = await this.web3.eth.getBlockNumber();
+            this.lastBlockCheck = Date.now();
+        }
+
+        return this.lastBlock;
+    }
+
+    /**
      * Gets all past events for the contract
      * @param contractName
      */
     async getAllPastEvents(contractName) {
         try {
-            const currentBlock = await this.web3.eth.getBlockNumber();
+            const currentBlock = await this.getCurrentBlock();
 
             let fromBlock = 0;
 

--- a/modules/Blockchain/Ethereum/index.js
+++ b/modules/Blockchain/Ethereum/index.js
@@ -18,12 +18,14 @@ class Ethereum {
         web3,
         logger,
         appState,
+        gasPriceService,
     }) {
         // Loading Web3
         this.appState = appState;
         this.emitter = emitter;
         this.web3 = web3;
         this.log = logger;
+        this.gasPriceService = gasPriceService;
 
         this.config = {
             wallet_address: config.node_wallet,
@@ -379,16 +381,17 @@ class Ethereum {
      * @param blockchainIdentity - ERC 725 identity (empty if there is none)
      * @return {Promise<any>}
      */
-    createProfile(
+    async createProfile(
         managementWallet,
         profileNodeId,
         initialBalance,
         isSender725,
         blockchainIdentity,
     ) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.profileContractAddress,
         };
         this.log.trace(`CreateProfile(${managementWallet}, ${profileNodeId}, ${initialBalance}, ${isSender725}, ${blockchainIdentity})`);
@@ -407,10 +410,11 @@ class Ethereum {
      * @param {number} tokenAmountIncrease
      * @returns {Promise}
      */
-    increaseProfileApproval(tokenAmountIncrease) {
+    async increaseProfileApproval(tokenAmountIncrease) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.tokenContractAddress,
         };
         this.log.trace(`increaseProfileApproval(amount=${tokenAmountIncrease})`);
@@ -423,10 +427,11 @@ class Ethereum {
      * @param amount
      * @return {Promise<any>}
      */
-    startTokenWithdrawal(blockchainIdentity, amount) {
+    async startTokenWithdrawal(blockchainIdentity, amount) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.profileContractAddress,
         };
         this.log.trace(`startTokenWithdrawal(blockchainIdentity=${blockchainIdentity}, amount=${amount}`);
@@ -438,10 +443,11 @@ class Ethereum {
      * @param blockchainIdentity
      * @return {Promise<any>}
      */
-    withdrawTokens(blockchainIdentity) {
+    async withdrawTokens(blockchainIdentity) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.profileContractAddress,
         };
         this.log.trace(`withdrawTokens(blockchainIdentity=${blockchainIdentity}`);
@@ -453,10 +459,11 @@ class Ethereum {
      * @param {number} tokenAmountIncrease
      * @returns {Promise}
      */
-    increaseBiddingApproval(tokenAmountIncrease) {
+    async increaseBiddingApproval(tokenAmountIncrease) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.tokenContractAddress,
         };
         this.log.notify('Increasing bidding approval');
@@ -464,26 +471,54 @@ class Ethereum {
     }
 
     /**
-     * Answers litigation from DH side
-     * @param offerId - Offer ID
-     * @param holderIdentity - DH identity
-     * @param answer - Litigation answer
+     * DC initiates litigation on DH wrong challenge answer
+     * @param importId
+     * @param dhWallet
+     * @param blockId
+     * @param merkleProof
      * @return {Promise<any>}
      */
-    answerLitigation(offerId, holderIdentity, answer) {
+    async initiateLitigation(importId, dhWallet, blockId, merkleProof) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
-            to: this.litigationContractAddress,
+            gasPrice: this.web3.utils.toHex(gasPrice),
+            to: this.escrowContractAddress,
         };
-        this.log.trace(`answerLitigation (offerId=${offerId}, holderIdentity=${holderIdentity}, answer=${answer})`);
+        this.log.important(`Initiates litigation for import ${importId} and DH ${dhWallet}`);
         return this.transactions.queueTransaction(
-            this.litigationContractAbi,
+            this.escrowContractAbi,
+            'initiateLitigation',
+            [
+                importId,
+                dhWallet,
+                blockId,
+                merkleProof,
+            ],
+            options,
+        );
+    }
+
+    /**
+     * Answers litigation from DH side
+     * @param importId
+     * @param requestedData
+     * @return {Promise<any>}
+     */
+    async answerLitigation(importId, requestedData) {
+        const gasPrice = await this.getGasPrice();
+        const options = {
+            gasLimit: this.web3.utils.toHex(this.config.gas_limit),
+            gasPrice: this.web3.utils.toHex(gasPrice),
+            to: this.escrowContractAddress,
+        };
+        this.log.important(`Answer litigation for import ${importId}`);
+        return this.transactions.queueTransaction(
+            this.escrowContractAbi,
             'answerLitigation',
             [
-                offerId,
-                holderIdentity,
-                answer,
+                importId,
+                requestedData,
             ],
             options,
         );
@@ -496,10 +531,11 @@ class Ethereum {
      * @param proofData
      * @return {Promise<any>}
      */
-    proveLitigation(importId, dhWallet, proofData) {
+    async proveLitigation(importId, dhWallet, proofData) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.escrowContractAddress,
         };
         this.log.important(`Prove litigation for import ${importId} and DH ${dhWallet}`);
@@ -519,20 +555,15 @@ class Ethereum {
      * Pay out tokens
      * @param blockchainIdentity
      * @param offerId
+     * @param urgent
      * @returns {Promise}
      */
-    async payOut(blockchainIdentity, offerId) {
-        let contractAddress = this.holdingContractAddress;
-
-        const offer = await this.getOffer(offerId);
-        if (Utilities.isZeroHash(offer['0'])) {
-            contractAddress = this.oldHoldingContractAddress;
-        }
-
+    async payOut(blockchainIdentity, offerId, urgent) {
+        const gasPrice = await this.getGasPrice(urgent);
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
-            to: contractAddress,
+            gasPrice: this.web3.utils.toHex(gasPrice),
+            to: this.holdingContractAddress,
         };
         this.log.trace(`payOut(blockchainIdentity=${blockchainIdentity}, offerId=${offerId}`);
         return this.transactions.queueTransaction(this.holdingContractAbi, 'payOut', [blockchainIdentity, offerId], options);
@@ -542,7 +573,7 @@ class Ethereum {
      * Creates offer for the data storing on the Ethereum blockchain.
      * @returns {Promise<any>} Return choose start-time.
      */
-    createOffer(
+    async createOffer(
         blockchainIdentity,
         dataSetId,
         dataRootHash,
@@ -554,10 +585,12 @@ class Ethereum {
         tokenAmountPerHolder,
         dataSizeInBytes,
         litigationIntervalInMinutes,
+        urgent,
     ) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.holdingContractAddress,
         };
         this.log.trace(`createOffer (${blockchainIdentity}, ${dataSetId}, ${dataRootHash}, ${redLitigationHash}, ${greenLitigationHash}, ${blueLitigationHash}, ${dcNodeId}, ${holdingTimeInMinutes}, ${tokenAmountPerHolder}, ${dataSizeInBytes}, ${litigationIntervalInMinutes})`);
@@ -594,18 +627,13 @@ class Ethereum {
         encryptionType,
         holders,
         parentIdentity,
+        urgent,
     ) {
-        let contractAddress = this.holdingContractAddress;
-
-        const offer = await this.getOffer(offerId);
-        if (Utilities.isZeroHash(offer['0'])) {
-            contractAddress = this.oldHoldingContractAddress;
-        }
-
+        const gasPrice = await this.getGasPrice(urgent);
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
-            to: contractAddress,
+            gasPrice: this.web3.utils.toHex(gasPrice),
+            to: this.holdingContractAddress,
         };
 
         this.log.trace(`finalizeOffer (${blockchainIdentity}, ${offerId}, ${shift}, ${confirmation1}, ${confirmation2}, ${confirmation3}, ${encryptionType}, ${holders}), ${parentIdentity}`);
@@ -905,10 +933,11 @@ class Ethereum {
      * @param dhNodeId KADemlia ID of the DH node that wants to add bid
      * @returns {Promise<any>} Index of the bid.
      */
-    addBid(importId, dhNodeId) {
+    async addBid(importId, dhNodeId) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.biddingContractAddress,
         };
 
@@ -927,9 +956,10 @@ class Ethereum {
      * @returns {Promise<any>}
      */
     async depositTokens(blockchainIdentity, amount) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.profileContractAddress,
         };
 
@@ -961,10 +991,11 @@ class Ethereum {
         return this.readingContract.methods.purchased_data(importId, wallet).call();
     }
 
-    initiatePurchase(importId, dhWallet, tokenAmount, stakeFactor) {
+    async initiatePurchase(importId, dhWallet, tokenAmount, stakeFactor) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -975,10 +1006,11 @@ class Ethereum {
         );
     }
 
-    sendCommitment(importId, dvWallet, commitment) {
+    async sendCommitment(importId, dvWallet, commitment) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -989,10 +1021,11 @@ class Ethereum {
         );
     }
 
-    initiateDispute(importId, dhWallet) {
+    async initiateDispute(importId, dhWallet) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1003,10 +1036,11 @@ class Ethereum {
         );
     }
 
-    confirmPurchase(importId, dhWallet) {
+    async confirmPurchase(importId, dhWallet) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1017,10 +1051,11 @@ class Ethereum {
         );
     }
 
-    cancelPurchase(importId, correspondentWallet, senderIsDh) {
+    async cancelPurchase(importId, correspondentWallet, senderIsDh) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1031,13 +1066,14 @@ class Ethereum {
         );
     }
 
-    sendProofData(
+    async sendProofData(
         importId, dvWallet, checksumLeft, checksumRight, checksumHash,
         randomNumber1, randomNumber2, decryptionKey, blockIndex,
     ) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1052,9 +1088,10 @@ class Ethereum {
     }
 
     async sendEncryptedBlock(importId, dvWallet, encryptedBlock) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1065,10 +1102,11 @@ class Ethereum {
         );
     }
 
-    payOutForReading(importId, dvWallet) {
+    async payOutForReading(importId, dvWallet, urgent) {
+        const gasPrice = await this.getGasPrice(urgent);
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.readingContractAddress,
         };
 
@@ -1176,10 +1214,11 @@ class Ethereum {
      * @param {string} - erc725identity
      * @param {string} - managementWallet
      */
-    transferProfile(erc725identity, managementWallet) {
+    async transferProfile(erc725identity, managementWallet) {
+        const gasPrice = await this.getGasPrice();
         const options = {
             gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
+            gasPrice: this.web3.utils.toHex(gasPrice),
             to: this.profileContractAddress,
         };
 
@@ -1213,75 +1252,29 @@ class Ethereum {
     }
 
     /**
-     * Get offer by offer ID
-     * @param offerId - Offer ID
-     * @return {Promise<any>}
+     * PayOut for multiple offers.
+     * @returns {Promise<any>}
      */
-    async getOffer(offerId) {
-        this.log.trace(`getOffer(offerId=${offerId})`);
-        return this.holdingStorageContract.methods.offer(offerId).call({
-            from: this.config.wallet_address,
-        });
-    }
-
-    /**
-     * Get holders for offer ID
-     * @param offerId - Offer ID
-     * @param holderIdentity - Holder identity
-     * @return {Promise<any>}
-     */
-    async getHolder(offerId, holderIdentity) {
-        this.log.trace(`getHolder(offerId=${offerId}, holderIdentity=${holderIdentity})`);
-        return this.holdingStorageContract.methods.holder(offerId, holderIdentity).call({
-            from: this.config.wallet_address,
-        });
-    }
-
-    /**
-     * Initiate litigation for the particular DH
-     * @param offerId - Offer ID
-     * @param holderIdentity - DH identity
-     * @param litigatorIdentity - Litigator identity
-     * @param requestedDataIndex - Block ID
-     * @param hashArray - Merkle proof
-     * @return {Promise<any>}
-     */
-    async initiateLitigation(
-        offerId, holderIdentity, litigatorIdentity,
-        requestedDataIndex, hashArray,
+    async payOutMultiple(
+        blockchainIdentity,
+        offerIds,
+        urgent,
     ) {
+        const gasLimit = offerIds.length * 200000;
+        const gasPrice = await this.getGasPrice(urgent);
         const options = {
-            gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
-            to: this.litigationContractAddress,
+            gasLimit,
+            gasPrice: this.web3.utils.toHex(gasPrice),
+            to: this.holdingContractAddress,
         };
-
-        this.log.trace(`initiateLitigation (offerId=${offerId}, holderIdentity=${holderIdentity}, litigatorIdentity=${litigatorIdentity}, requestedDataIndex=${requestedDataIndex}, hashArray=${hashArray})`);
+        this.log.trace(`payOutMultiple (identity=${blockchainIdentity}, offerIds=${offerIds}`);
         return this.transactions.queueTransaction(
-            this.litigationContractAbi, 'initiateLitigation',
-            [offerId, holderIdentity, litigatorIdentity, requestedDataIndex, hashArray], options,
-        );
-    }
-
-    /**
-     * Completes litigation for the particular DH
-     * @param offerId - Offer ID
-     * @param holderIdentity - DH identity
-     * @param challengerIdentity - DC identity
-     * @param proofData - answer
-     * @return {Promise<void>}
-     */
-    async completeLitigation(offerId, holderIdentity, challengerIdentity, proofData) {
-        const options = {
-            gasLimit: this.web3.utils.toHex(this.config.gas_limit),
-            gasPrice: this.web3.utils.toHex(this.config.gas_price),
-            to: this.litigationContractAddress,
-        };
-
-        this.log.trace(`completeLitigation (offerId=${offerId}, holderIdentity=${holderIdentity}, challengerIdentity=${challengerIdentity}, proofData=${proofData})`);
-        return this.transactions.queueTransaction(
-            this.litigationContractAbi, 'completeLitigation',
-            [offerId, holderIdentity, challengerIdentity, proofData], options,
+            this.holdingContractAbi, 'payOutMultiple',
+            [
+                blockchainIdentity,
+                offerIds,
+            ],
+            options,
         );
     }
 
@@ -1323,28 +1316,6 @@ class Ethereum {
         this.log.trace(`getLitigationReplacementTask(offerId=${offerId}, holderIdentity=${holderIdentity})`);
         return this.litigationStorageContract
             .methods.getLitigationReplacementTask(offerId, holderIdentity).call({
-                from: this.config.wallet_address,
-            });
-    }
-
-    /**
-     * Get staked amount for the holder
-     */
-    async getHolderStakedAmount(offerId, holderIdentity) {
-        this.log.trace(`getHolderStakedAmount(offer=${offerId}, holderIdentity=${holderIdentity})`);
-        return this.holdingStorageContract.methods
-            .getHolderStakedAmount(offerId, holderIdentity).call({
-                from: this.config.wallet_address,
-            });
-    }
-
-    /**
-     * Get paid amount for the holder
-     */
-    async getHolderPaidAmount(offerId, holderIdentity) {
-        this.log.trace(`getHolderPaidAmount(offer=${offerId}, holderIdentity=${holderIdentity})`);
-        return this.holdingStorageContract.methods
-            .getHolderPaidAmount(offerId, holderIdentity).call({
                 from: this.config.wallet_address,
             });
     }
@@ -1399,6 +1370,54 @@ class Ethereum {
             }
         });
         return totalAmount.toString();
+    }
+
+    /**
+     * Get offer by offer ID
+     * @param offerId - Offer ID
+     * @return {Promise<any>}
+     */
+    async getOffer(offerId) {
+        this.log.trace(`getOffer(offerId=${offerId})`);
+        return this.holdingStorageContract.methods.offer(offerId).call({
+            from: this.config.wallet_address,
+        });
+    }
+
+    /**
+     * Get staked amount for the holder
+     */
+    async getHolderStakedAmount(offerId, holderIdentity) {
+        this.log.trace(`getHolderStakedAmount(offer=${offerId}, holderIdentity=${holderIdentity})`);
+        return this.holdingStorageContract.methods
+            .getHolderStakedAmount(offerId, holderIdentity).call({
+                from: this.config.wallet_address,
+            });
+    }
+
+    /**
+     * Get paid amount for the holder
+     */
+    async getHolderPaidAmount(offerId, holderIdentity) {
+        this.log.trace(`getHolderPaidAmount(offer=${offerId}, holderIdentity=${holderIdentity})`);
+        return this.holdingStorageContract.methods
+            .getHolderPaidAmount(offerId, holderIdentity).call({
+                from: this.config.wallet_address,
+            });
+    }
+
+    /**
+     * Returns gas price, throws error if not urgent and gas price higher than maximum allowed price
+     * @param urgent
+     * @returns {Promise<*|number>}
+     */
+    async getGasPrice(urgent = false) {
+        const gasPrice = await this.gasPriceService.getGasPrice();
+        if (gasPrice > this.config.max_allowed_gas_price && !urgent) {
+            throw new Error('Gas price higher than maximum allowed price');
+        } else {
+            return gasPrice;
+        }
     }
 }
 

--- a/modules/command/dc/dc-offer-choose-command.js
+++ b/modules/command/dc/dc-offer-choose-command.js
@@ -29,6 +29,7 @@ class DCOfferChooseCommand extends Command {
             excludedDHs,
             isReplacement,
             dhIdentity,
+            urgent,
         } = command.data;
 
         const offer = await models.offers.findOne({ where: { id: internalOfferId } });

--- a/modules/command/dc/dc-offer-create-bc-command.js
+++ b/modules/command/dc/dc-offer-create-bc-command.js
@@ -1,6 +1,7 @@
 const Command = require('../command');
 const Models = require('../../../models/index');
 const Utilities = require('../../Utilities');
+const constants = require('../../constants');
 
 /**
  * Creates offer on blockchain
@@ -31,21 +32,36 @@ class DCOfferCreateBcCommand extends Command {
             tokenAmountPerHolder,
             dataSizeInBytes,
             litigationIntervalInMinutes,
+            urgent,
         } = command.data;
 
-        const result = await this.blockchain.createOffer(
-            Utilities.normalizeHex(this.config.erc725Identity),
-            dataSetId,
-            dataRootHash,
-            redLitigationHash,
-            greenLitigationHash,
-            blueLitigationHash,
-            Utilities.normalizeHex(this.config.identity),
-            holdingTimeInMinutes,
-            tokenAmountPerHolder,
-            dataSizeInBytes,
-            litigationIntervalInMinutes,
-        );
+        let result;
+
+
+        try {
+            result = await this.blockchain.createOffer(
+                Utilities.normalizeHex(this.config.erc725Identity),
+                dataSetId,
+                dataRootHash,
+                redLitigationHash,
+                greenLitigationHash,
+                blueLitigationHash,
+                Utilities.normalizeHex(this.config.identity),
+                holdingTimeInMinutes,
+                tokenAmountPerHolder,
+                dataSizeInBytes,
+                litigationIntervalInMinutes,
+                urgent,
+            );
+        } catch (error) {
+            if (error.message.includes('Gas price higher than maximum allowed price')) {
+                this.logger.info('Gas price too high, delaying call for 30 minutes');
+                return Command.repeat();
+            }
+            throw error;
+        }
+
+
         this.logger.important(`Offer with internal ID ${internalOfferId} for data set ${dataSetId} written to blockchain. Waiting for DHs...`);
 
         const offer = await Models.offers.findOne({ where: { id: internalOfferId } });
@@ -95,6 +111,7 @@ class DCOfferCreateBcCommand extends Command {
         const command = {
             name: 'dcOfferCreateBcCommand',
             delay: 0,
+            period: constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS,
             transactional: false,
         };
         Object.assign(command, map);

--- a/modules/command/dc/dc-offer-create-db-command.js
+++ b/modules/command/dc/dc-offer-create-db-command.js
@@ -28,6 +28,7 @@ class DCOfferCreateDbCommand extends Command {
             holdingTimeInMinutes,
             tokenAmountPerHolder,
             litigationIntervalInMinutes,
+            urgent,
         } = command.data;
 
         const offer = await models.offers.findOne({ where: { id: internalOfferId } });
@@ -37,6 +38,7 @@ class DCOfferCreateDbCommand extends Command {
         offer.blue_litigation_hash = blueLitigationHash.toString('hex');
         offer.green_litigation_hash = greenLitigationHash.toString('hex');
         offer.litigation_interval_in_minutes = litigationIntervalInMinutes.toString();
+        offer.urgent = !!urgent;
         offer.message = 'Offer has been prepared for BC.';
         offer.status = 'PREPARED';
 
@@ -44,7 +46,7 @@ class DCOfferCreateDbCommand extends Command {
             fields: [
                 'holding_time_in_minutes', 'token_amount_per_holder',
                 'red_litigation_hash', 'blue_litigation_hash', 'green_litigation_hash',
-                'litigation_interval_in_minutes', 'message', 'status'],
+                'litigation_interval_in_minutes', 'urgent', 'message', 'status'],
         });
         this.remoteControl.offerUpdate({
             id: internalOfferId,

--- a/modules/command/dc/dc-offer-finalize-command.js
+++ b/modules/command/dc/dc-offer-finalize-command.js
@@ -54,6 +54,9 @@ class DCOfferFinalizeCommand extends Command {
         }
 
         try {
+            const parentIdentity = this.config.parentIdentity ?
+                Utilities.normalizeHex(this.config.parentIdentity) : new BN(0, 16);
+
             await this.blockchain.finalizeOffer(
                 Utilities.normalizeHex(this.config.erc725Identity),
                 offerId,
@@ -63,6 +66,7 @@ class DCOfferFinalizeCommand extends Command {
                 confirmations[2],
                 colors,
                 nodeIdentifiers,
+                parentIdentity,
                 urgent,
             );
         } catch (error) {

--- a/modules/command/dc/dc-offer-mining-completed-command.js
+++ b/modules/command/dc/dc-offer-mining-completed-command.js
@@ -98,7 +98,8 @@ class DcOfferMiningCompletedCommand extends Command {
                     throw new Error(message);
                 }
             }
-            const commandData = { offerId, solution };
+
+            const commandData = { offerId, solution, urgent: offer.urgent };
             const commandSequence = ['dcOfferFinalizeCommand'];
             return {
                 commands: [

--- a/modules/command/dh/dh-pay-out-command.js
+++ b/modules/command/dh/dh-pay-out-command.js
@@ -71,9 +71,9 @@ class DhPayOutCommand extends Command {
      */
     async recover(command, err) {
         const {
-                offerId,
-                viaAPI,
-            } = command.data;
+            offerId,
+            viaAPI,
+        } = command.data;
 
         if (!viaAPI) {
             this.logger.warn(`Rescheduling failed payout for offer ${offerId}. Schedule delay ${DELAY_ON_FAIL_IN_MILLS} milliseconds`);

--- a/modules/command/dh/dh-replacement-handle-command.js
+++ b/modules/command/dh/dh-replacement-handle-command.js
@@ -11,7 +11,7 @@ const ImportUtilities = require('../../ImportUtilities');
 /**
  * Imports data for replication
  */
-class DHReplacementImportCommand extends Command {
+class DHReplacementHandleCommand extends Command {
     constructor(ctx) {
         super(ctx);
         this.config = ctx.config;
@@ -274,7 +274,7 @@ class DHReplacementImportCommand extends Command {
      */
     default(map) {
         const command = {
-            name: 'dhReplacementImportCommand',
+            name: 'dhReplacementHandleCommand',
             delay: 10000,
             transactional: false,
         };
@@ -283,4 +283,4 @@ class DHReplacementImportCommand extends Command {
     }
 }
 
-module.exports = DHReplacementImportCommand;
+module.exports = DHReplacementHandleCommand;

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -36,3 +36,15 @@ exports.MAX_COMMAND_DELAY_IN_MILLS = 14400 * 60 * 1000; // 10 days
  * @constant {number} DEFAULT_COMMAND_REPEAT_IN_MILLS - Default repeat interval
  */
 exports.DEFAULT_COMMAND_REPEAT_INTERVAL_IN_MILLS = 5000; // 5 seconds
+
+/**
+ *
+ * @constant {number} GAS_PRICE_VALIDITY_TIME_IN_MILLS - gas price maximum validity time
+ */
+exports.GAS_PRICE_VALIDITY_TIME_IN_MILLS = 30 * 60 * 1000; // 30 min
+
+/**
+ *
+ * @constant {number} AVERAGE_GAS_PRICE_MULTIPLIER - gas price multiplier
+ */
+exports.AVERAGE_GAS_PRICE_MULTIPLIER = 1.2; // 30 min

--- a/modules/controller/dc-controller.js
+++ b/modules/controller/dc-controller.js
@@ -42,6 +42,7 @@ class DCController {
                 tokenAmountPerHolder: req.body.token_amount_per_holder,
                 litigationIntervalInMinutes: req.body.litigation_interval_in_minutes,
                 response: res,
+                urgent: req.body.urgent,
             };
             this.emitter.emit('api-create-offer', queryObject);
         } else {

--- a/modules/controller/import-controller.js
+++ b/modules/controller/import-controller.js
@@ -46,6 +46,7 @@ class ImportController {
                     content,
                     contact: req.contact,
                     replicate: req.body.replicate,
+                    urgent: req.body.urgent,
                     response: res,
                 };
                 this.emitter.emit(`api-${importtype}-import-request`, queryObject);
@@ -61,6 +62,7 @@ class ImportController {
                 content: req.body.importfile,
                 contact: req.contact,
                 replicate: req.body.replicate,
+                urgent: req.body.urgent,
                 response: res,
             };
             this.emitter.emit(`api-${importtype}-import-request`, queryObject);

--- a/modules/service/axios-service.js
+++ b/modules/service/axios-service.js
@@ -1,0 +1,17 @@
+const axios = require('axios');
+
+class AxiosService {
+    async getGasPrice() {
+        const response = await axios.get('https://ethgasstation.info/json/ethgasAPI.json')
+            .catch((err) => {
+                this.log.warn(err);
+                return undefined;
+            });
+        if (response) {
+            return response.data.average * 100000000;
+        }
+        return undefined;
+    }
+}
+
+module.exports = AxiosService;

--- a/modules/service/dc-service.js
+++ b/modules/service/dc-service.js
@@ -30,7 +30,7 @@ class DCService {
      */
     async createOffer(
         dataSetId, dataRootHash, holdingTimeInMinutes, tokenAmountPerHolder,
-        dataSizeInBytes, litigationIntervalInMinutes,
+        dataSizeInBytes, litigationIntervalInMinutes, urgent,
     ) {
         const offer = await models.offers.create({
             data_set_id: dataSetId,
@@ -82,6 +82,7 @@ class DCService {
             tokenAmountPerHolder,
             dataSizeInBytes,
             litigationIntervalInMinutes,
+            urgent,
         };
         const commandSequence = [
             'dcOfferPrepareCommand',

--- a/modules/service/dh-service.js
+++ b/modules/service/dh-service.js
@@ -160,7 +160,7 @@ class DHService {
 
         await this.commandExecutor.add({
             name: 'dhOfferHandleCommand',
-            delay: 15000,
+            delay: 45000,
             data,
             transactional: false,
         });
@@ -331,7 +331,7 @@ class DHService {
 
         await this.commandExecutor.add({
             name: 'dhReplacementHandleCommand',
-            delay: 15000,
+            delay: 45000,
             data: {
                 offerId,
                 litigatorIdentity,

--- a/modules/service/gas-price-service.js
+++ b/modules/service/gas-price-service.js
@@ -1,0 +1,48 @@
+const constants = require('../constants');
+const Web3 = require('web3');
+
+class GasPriceService {
+    constructor(ctx) {
+        this.logger = ctx.logger;
+        this.config = ctx.config;
+        this.axiosService = ctx.axiosService;
+        this.web3 = ctx.web3;
+    }
+
+    async getGasPrice() {
+        if (process.env.NODE_ENV !== 'mariner' && process.env.NODE_ENV !== 'production') {
+            return this.config.blockchain.gas_price;
+        }
+
+        const now = new Date().getTime();
+        if (this.config.blockchain.gas_price_last_update_timestamp
+            + constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS > now) {
+            return this.config.blockchain.gas_price;
+        }
+        const axiosGasPrice = await this.axiosService.getGasPrice()
+            .catch((err) => { this.logger.warn(err); }) * constants.AVERAGE_GAS_PRICE_MULTIPLIER;
+
+        const web3GasPrice = await this.web3.eth.getGasPrice()
+            .catch((err) => { this.logger.warn(err); }) * constants.AVERAGE_GAS_PRICE_MULTIPLIER;
+
+        if (axiosGasPrice && web3GasPrice) {
+            const gasPrice = (axiosGasPrice > web3GasPrice ? axiosGasPrice : web3GasPrice);
+            this.saveNewGasPriceAndTime(gasPrice);
+            return gasPrice;
+        } else if (axiosGasPrice) {
+            this.saveNewGasPriceAndTime(axiosGasPrice);
+            return axiosGasPrice;
+        } else if (web3GasPrice) {
+            this.saveNewGasPriceAndTime(web3GasPrice);
+            return web3GasPrice;
+        }
+        return this.config.blockchain.gas_price;
+    }
+
+    saveNewGasPriceAndTime(gasPrice) {
+        this.config.blockchain.gas_price = gasPrice;
+        this.config.blockchain.gas_price_last_update_timestamp = new Date().getTime();
+    }
+}
+
+module.exports = GasPriceService;

--- a/modules/service/profile-service.js
+++ b/modules/service/profile-service.js
@@ -4,6 +4,7 @@ const path = require('path');
 const EthereumAbi = require('ethereumjs-abi');
 
 const Utilities = require('../Utilities');
+const constants = require('../constants');
 
 class ProfileService {
     /**
@@ -58,26 +59,71 @@ class ProfileService {
             initialTokenAmount = new BN(profileMinStake, 10);
         }
 
-        await this.blockchain.increaseProfileApproval(initialTokenAmount);
+        let approvalIncreased = false;
+        do {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await this.blockchain.increaseProfileApproval(initialTokenAmount);
+                approvalIncreased = true;
+            } catch (error) {
+                if (error.message.includes('Gas price higher than maximum allowed price')) {
+                    this.logger.warn('Current average gas price is too high, to force profile' +
+                        ' creation increase max_allowed_gas_price in your configuration file and reset the node.' +
+                        ' Retrying in 30 minutes...');
+                    // eslint-disable-next-line no-await-in-loop
+                    await new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve();
+                        }, constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS);
+                    });
+                } else {
+                    throw error;
+                }
+            }
+        } while (approvalIncreased === false);
 
         // set empty identity if there is none
         const identity = this.config.erc725Identity ? this.config.erc725Identity : new BN(0, 16);
 
-        if (this.config.management_wallet) {
-            await this.blockchain.createProfile(
-                this.config.management_wallet,
-                this.config.identity,
-                initialTokenAmount, identityExists, identity,
-            );
-        } else {
-            this.logger.important('Management wallet not set. Creating profile with operating wallet only.' +
-                    ' Please set management one.');
-            await this.blockchain.createProfile(
-                this.config.node_wallet,
-                this.config.identity,
-                initialTokenAmount, identityExists, identity,
-            );
-        }
+        let createProfileCalled = false;
+        do {
+            try {
+                if (this.config.management_wallet) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.blockchain.createProfile(
+                        this.config.management_wallet,
+                        this.config.identity,
+                        initialTokenAmount, identityExists, identity,
+                    );
+                    createProfileCalled = true;
+                } else {
+                    this.logger.important('Management wallet not set. Creating profile with operating wallet only.' +
+                            ' Please set management one.');
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.blockchain.createProfile(
+                        this.config.node_wallet,
+                        this.config.identity,
+                        initialTokenAmount, identityExists, identity,
+                    );
+                    createProfileCalled = true;
+                }
+            } catch (error) {
+                if (error.message.includes('Gas price higher than maximum allowed price')) {
+                    this.logger.warn('Current average gas price is too high, to force profile' +
+                        ' creation increase max_allowed_gas_price in your configuration file and reset the node.' +
+                        ' Retrying in 30 minutes...');
+                    // eslint-disable-next-line no-await-in-loop
+                    await new Promise((resolve) => {
+                        setTimeout(() => {
+                            resolve();
+                        }, constants.GAS_PRICE_VALIDITY_TIME_IN_MILLS);
+                    });
+                } else {
+                    throw error;
+                }
+            }
+        } while (createProfileCalled === false);
+
         if (!identityExists) {
             const event = await this.blockchain.subscribeToEvent('IdentityCreated', null, 5 * 60 * 1000, null, eventData => Utilities.compareHexStrings(eventData.profile, this.config.node_wallet));
             if (event) {

--- a/ot-node.js
+++ b/ot-node.js
@@ -547,18 +547,18 @@ class OTNode {
     listenBlockchainEvents(blockchain) {
         log.info('Starting blockchain event listener');
 
-        const delay = 10000;
+        const delay = 20000;
         let working = false;
         let deadline = Date.now();
-        setInterval(() => {
+        setInterval(async () => {
             if (!working && Date.now() > deadline) {
                 working = true;
-                blockchain.getAllPastEvents('HOLDING_CONTRACT');
-                blockchain.getAllPastEvents('PROFILE_CONTRACT');
-                blockchain.getAllPastEvents('APPROVAL_CONTRACT');
-                blockchain.getAllPastEvents('LITIGATION_CONTRACT');
-                blockchain.getAllPastEvents('REPLACEMENT_CONTRACT');
-                blockchain.getAllPastEvents('OLD_HOLDING_CONTRACT'); // TODO remove after successful migration
+                await blockchain.getAllPastEvents('HOLDING_CONTRACT');
+                await blockchain.getAllPastEvents('PROFILE_CONTRACT');
+                await blockchain.getAllPastEvents('APPROVAL_CONTRACT');
+                await blockchain.getAllPastEvents('LITIGATION_CONTRACT');
+                await blockchain.getAllPastEvents('REPLACEMENT_CONTRACT');
+                await blockchain.getAllPastEvents('OLD_HOLDING_CONTRACT'); // TODO remove after successful migration
                 deadline = Date.now() + delay;
                 working = false;
             }

--- a/ot-node.js
+++ b/ot-node.js
@@ -28,6 +28,8 @@ const uuidv4 = require('uuid/v4');
 const awilix = require('awilix');
 const homedir = require('os').homedir();
 const argv = require('minimist')(process.argv.slice(2));
+const AxiosService = require('./modules/service/axios-service');
+
 const Graph = require('./modules/Graph');
 const Product = require('./modules/Product');
 
@@ -42,6 +44,7 @@ const ImportController = require('./modules/controller/import-controller');
 const APIUtilities = require('./modules/api-utilities');
 const RestAPIService = require('./modules/service/rest-api-service');
 const M2SequelizeMetaMigration = require('./modules/migration/m2-sequelize-meta-migration');
+const GasPriceService = require('./modules/service/gas-price-service');
 
 const pjson = require('./package.json');
 const configjson = require('./config/config.json');
@@ -371,7 +374,8 @@ class OTNode {
             minerService: awilix.asClass(MinerService).singleton(),
             replicationService: awilix.asClass(ReplicationService).singleton(),
             restAPIService: awilix.asClass(RestAPIService).singleton(),
-            challengeService: awilix.asClass(ChallengeService).singleton(),
+            axiosService: awilix.asClass(AxiosService).singleton(),
+            gasPriceService: awilix.asClass(GasPriceService).singleton(),
         });
         const blockchain = container.resolve('blockchain');
         await blockchain.initialize();
@@ -509,6 +513,8 @@ class OTNode {
             transport: awilix.asValue(Transport()),
             apiUtilities: awilix.asClass(APIUtilities).singleton(),
             restAPIService: awilix.asClass(RestAPIService).singleton(),
+            axiosService: awilix.asClass(AxiosService).singleton(),
+            gasPriceService: awilix.asClass(GasPriceService).singleton(),
         });
 
         const transport = container.resolve('transport');

--- a/ot-node.js
+++ b/ot-node.js
@@ -374,6 +374,7 @@ class OTNode {
             minerService: awilix.asClass(MinerService).singleton(),
             replicationService: awilix.asClass(ReplicationService).singleton(),
             restAPIService: awilix.asClass(RestAPIService).singleton(),
+            challengeService: awilix.asClass(ChallengeService).singleton(),
             axiosService: awilix.asClass(AxiosService).singleton(),
             gasPriceService: awilix.asClass(GasPriceService).singleton(),
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origintrail_node",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "OriginTrail node",
   "main": ".eslintrc.js",
   "config": {

--- a/setup_arangodb.sh
+++ b/setup_arangodb.sh
@@ -10,7 +10,7 @@ echo arangodb3 arangodb3/upgrade boolean true | debconf-set-selections
 echo arangodb3 arangodb3/storage_engine select mmfiles | debconf-set-selections
 echo arangodb3 arangodb3/password password root | debconf-set-selections
 echo arangodb3 arangodb3/password_again password root | debconf-set-selections
-apt-get install arangodb3=3.3.12 -y
+apt-get install arangodb3=3.3.12 -y --allow-unauthenticated
 
 sed -i 's/authentication = true/authentication = false/g' /etc/arangodb3/arangod.conf
 systemctl start arangodb3

--- a/test/bdd/features/litigation.feature
+++ b/test/bdd/features/litigation.feature
@@ -1,9 +1,9 @@
-@third
 Feature: Test various litigation scenarios
   Background: Setup local blockchain and bootstraps
     Given the blockchain is set up
     And 1 bootstrap is running
 
+  @third
   Scenario: Test litigation for one holder which is not responding
     Given the replication difficulty is 0
     And I setup 8 node
@@ -37,6 +37,7 @@ Feature: Test various litigation scenarios
     Then I wait for 3 replacement replications to finish
     Then I wait for replacement to be completed
 
+  @third
   Scenario: Test litigation for one holder which has failed to answer challenge but succeeded to answer litigation (wrongly)
     Given the replication difficulty is 0
     And I setup 7 node
@@ -59,6 +60,7 @@ Feature: Test various litigation scenarios
     Then I wait for 3 replacement replications to finish
     Then I wait for replacement to be completed
 
+  @fourth
   Scenario: Test litigation for one holder which has failed to answer challenge but succeeded to answer litigation (correctly)
     Given the replication difficulty is 0
     And I setup 7 node
@@ -83,6 +85,7 @@ Feature: Test various litigation scenarios
     Then Litigator node should have completed litigation
     Then 1st started holder should not have been penalized
 
+  @fourth
   Scenario: Test litigation case where same new nodes will apply for same offer
     Given the replication difficulty is 0
     And I setup 4 nodes
@@ -105,6 +108,7 @@ Feature: Test various litigation scenarios
     Then I wait for 3 replacement replications to finish
     Then I wait for replacement to be completed
 
+  @fourth
   Scenario: Test litigation case
     Given the replication difficulty is 0
     And I setup 4 nodes

--- a/test/modules/service/gas-price-service-test.js
+++ b/test/modules/service/gas-price-service-test.js
@@ -1,0 +1,111 @@
+const {
+    describe, before, beforeEach, it,
+} = require('mocha');
+const GasPriceService = require('../../../modules/service/gas-price-service');
+const awilix = require('awilix');
+const defaultConfig = require('../../../config/config.json').mariner;
+const rc = require('rc');
+const pjson = require('../../../package.json');
+const logger = require('../../../modules/logger');
+const { assert } = require('chai');
+const constants = require('../../../modules/constants');
+
+let gasPriceService;
+let axiosServiceMock;
+let web3ServiceMock;
+
+const defaultConfigGasPrice = 30000000000;
+const defaultAxiosGasPrice = 20000000000;
+const defaultWeb3GasPrice = 10000000000;
+let config;
+
+class AxiosServiceMock {
+    constructor(logger) {
+        this.logger = logger;
+        this.gasPrice = defaultAxiosGasPrice;
+        this.logger.debug('Axios service mock initialized');
+    }
+
+    async getGasPrice() {
+        this.logger.debug('Returning axios service gas price');
+        return this.gasPrice;
+    }
+}
+
+class Web3Mock {
+    constructor(logger) {
+        this.logger = logger;
+        this.eth = {
+            gasPrice: defaultWeb3GasPrice,
+            async getGasPrice() {
+                return this.gasPrice;
+            },
+        };
+    }
+}
+
+describe('Gas price service test', () => {
+    beforeEach('Setup container', async () => {
+        // Create the container and set the injectionMode to PROXY (which is also the default).
+        process.env.NODE_ENV = 'mariner';
+        const container = awilix.createContainer({
+            injectionMode: awilix.InjectionMode.PROXY,
+        });
+
+        config = rc(pjson.name, defaultConfig);
+        config.blockchain.gas_price = defaultConfigGasPrice;
+        config.blockchain.gas_price_last_update_timestamp = 0;
+        axiosServiceMock = new AxiosServiceMock(logger);
+        web3ServiceMock = new Web3Mock(logger);
+        container.register({
+            config: awilix.asValue(config),
+            logger: awilix.asValue(logger),
+            axiosService: awilix.asValue(axiosServiceMock),
+            web3: awilix.asValue(web3ServiceMock),
+        });
+        gasPriceService = new GasPriceService(container.cradle);
+    });
+
+    it('Get gas price - env is develop - expect default is returned', async () => {
+        process.env.NODE_ENV = 'develop';
+        const gasPrice = await gasPriceService.getGasPrice();
+        assert.equal(gasPrice, defaultConfigGasPrice, 'Gas price should be the same as in config');
+    });
+
+    it('Get gas price - env is mariner, all services return valid value - expect axios value is used', async () => {
+        const gasPrice = await gasPriceService.getGasPrice();
+        assert.equal(gasPrice, defaultAxiosGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Returned gas price price should be the same as default axios gas price');
+        assert.equal(config.blockchain.gas_price, defaultAxiosGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Configuration gas price should be the same as default axios gas price');
+        const now = new Date().getTime();
+        assert.closeTo(config.blockchain.gas_price_last_update_timestamp, now, 1000, 'Now should be set as new timestamp');
+    });
+
+    it('Get gas price - env is mariner, all services return valid value, timestamp is not older than 30 min - expect config value is used', async () => {
+        const lastUpdateTimestamp = new Date().getTime() - (1000 * 25);
+        config.blockchain.gas_price_last_update_timestamp = lastUpdateTimestamp;
+        gasPriceService.config = config;
+        const gasPrice = await gasPriceService.getGasPrice();
+        assert.equal(gasPrice, config.blockchain.gas_price, 'Gas price should be the same as default config');
+        assert.equal(config.blockchain.gas_price_last_update_timestamp, lastUpdateTimestamp, 'Timestamp should not be changed');
+    });
+
+    it('Get gas price - env is mariner, axios returns undefined - expect web3 value is used', async () => {
+        axiosServiceMock.gasPrice = undefined;
+        gasPriceService.axiosService = axiosServiceMock;
+        const gasPrice = await gasPriceService.getGasPrice();
+        assert.equal(gasPrice, defaultWeb3GasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default web3');
+        assert.equal(config.blockchain.gas_price, defaultWeb3GasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default web3');
+        const now = new Date().getTime();
+        assert.closeTo(config.blockchain.gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
+    });
+
+    it('Get gas price - env is mariner, web3 returns undefined - expect axios value is used', async () => {
+        web3ServiceMock.eth.gasPrice = undefined;
+        gasPriceService.web3 = web3ServiceMock;
+        const gasPrice = await gasPriceService.getGasPrice();
+        assert.equal(gasPrice, defaultAxiosGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default axios');
+        assert.equal(config.blockchain.gas_price, defaultAxiosGasPrice * constants.AVERAGE_GAS_PRICE_MULTIPLIER, 'Gas price should be the same as default axios');
+        const now = new Date().getTime();
+        assert.closeTo(config.blockchain.gas_price_last_update_timestamp, now, 1000, 'Timestamp should not be changed');
+    });
+});

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -27,7 +27,7 @@ describe('Utilities module', () => {
                     'is_bootstrap_node', 'houston_password', 'enable_debug_logs_level', 'reverse_tunnel_address', 'reverse_tunnel_port',
                     'autoUpdater', 'bugSnag', 'network', 'dataSetStorage', 'dc_holding_time_in_minutes', 'dc_choose_time', 'dc_litigation_interval_in_minutes',
                     'dc_token_amount_per_holder', 'dh_max_holding_time_in_minutes', 'dh_min_litigation_interval_in_minutes', 'dh_min_token_price',
-                    'erc725_identity_filepath', 'deposit_on_demand', 'requireApproval', 'dh_max_data_set_size'],
+                    'erc725_identity_filepath', 'deposit_on_demand', 'requireApproval', 'litigationEnabled', 'commandExecutorVerboseLoggingEnabled'],
                 `Some config items are missing in config for environment '${environment}'`,
             );
             assert.hasAllKeys(
@@ -42,11 +42,17 @@ describe('Utilities module', () => {
             );
             assert.hasAllKeys(
                 config.network, [
-                    'id', 'hostname', 'bootstraps',
+                    'id', 'hostname', 'bootstraps', 'churnPlugin',
                     'remoteWhitelist', 'identityDifficulty',
                     'solutionDifficulty',
                 ],
                 `Some config items are missing in config.network for environment '${environment}'`,
+            );
+            assert.hasAllKeys(
+                config.network.churnPlugin, [
+                    'cooldownBaseTimeout', 'cooldownMultiplier', 'cooldownResetTime',
+                ],
+                `Some config items are missing in config.network.churnPlugin for environment '${environment}'`,
             );
             assert.hasAllKeys(
                 config.bugSnag, ['releaseStage'],

--- a/test/modules/utilities.test.js
+++ b/test/modules/utilities.test.js
@@ -27,7 +27,7 @@ describe('Utilities module', () => {
                     'is_bootstrap_node', 'houston_password', 'enable_debug_logs_level', 'reverse_tunnel_address', 'reverse_tunnel_port',
                     'autoUpdater', 'bugSnag', 'network', 'dataSetStorage', 'dc_holding_time_in_minutes', 'dc_choose_time', 'dc_litigation_interval_in_minutes',
                     'dc_token_amount_per_holder', 'dh_max_holding_time_in_minutes', 'dh_min_litigation_interval_in_minutes', 'dh_min_token_price',
-                    'erc725_identity_filepath', 'deposit_on_demand', 'requireApproval', 'litigationEnabled', 'commandExecutorVerboseLoggingEnabled'],
+                    'erc725_identity_filepath', 'deposit_on_demand', 'requireApproval', 'dh_max_data_set_size'],
                 `Some config items are missing in config for environment '${environment}'`,
             );
             assert.hasAllKeys(
@@ -36,23 +36,17 @@ describe('Utilities module', () => {
             );
             assert.hasAllKeys(
                 config.blockchain, [
-                    'blockchain_title', 'network_id', 'gas_limit', 'gas_price',
+                    'blockchain_title', 'network_id', 'gas_limit', 'gas_price', 'max_allowed_gas_price',
                     'hub_contract_address', 'plugins'],
                 `Some config items are missing in config.blockchain for environment '${environment}'`,
             );
             assert.hasAllKeys(
                 config.network, [
-                    'id', 'hostname', 'bootstraps', 'churnPlugin',
+                    'id', 'hostname', 'bootstraps',
                     'remoteWhitelist', 'identityDifficulty',
                     'solutionDifficulty',
                 ],
                 `Some config items are missing in config.network for environment '${environment}'`,
-            );
-            assert.hasAllKeys(
-                config.network.churnPlugin, [
-                    'cooldownBaseTimeout', 'cooldownMultiplier', 'cooldownResetTime',
-                ],
-                `Some config items are missing in config.network.churnPlugin for environment '${environment}'`,
             );
             assert.hasAllKeys(
                 config.bugSnag, ['releaseStage'],
@@ -96,7 +90,7 @@ describe('Utilities module', () => {
         environments.forEach((environment) => {
             const config = configJson[environment];
             assert.hasAllKeys(config.blockchain, ['blockchain_title', 'network_id', 'gas_limit', 'plugins',
-                'gas_price', 'hub_contract_address']);
+                'gas_price', 'max_allowed_gas_price', 'hub_contract_address']);
             assert.equal(config.blockchain.blockchain_title, 'Ethereum');
         });
     });

--- a/testnet/install-arango.sh
+++ b/testnet/install-arango.sh
@@ -9,4 +9,4 @@ echo arangodb3 arangodb3/upgrade boolean true | debconf-set-selections
 echo arangodb3 arangodb3/storage_engine select mmfiles | debconf-set-selections
 echo arangodb3 arangodb3/password password root | debconf-set-selections
 echo arangodb3 arangodb3/password_again password root | debconf-set-selections
-apt-get install arangodb3=3.3.12 -y
+apt-get install arangodb3=3.3.12 -y --allow-unauthenticated


### PR DESCRIPTION
Dynamic gas-price calculating.

## Proposed Changes

- Added the maximum allowed gas price for which the node will send transactions (max_allowed_gas_price in the config file.). The default value is set to 50 gWei
- Added ‘urgent’ parameter, which will force the node to publish the transaction regardless of gas price, added to import and replication API calls
- If the average gas price is higher than the ‘max_allowed_gas_price’, and the parameter urgent is not set, the node will wait for 30 minutes, and then try again
